### PR TITLE
Add camera selection to Auditor rules

### DIFF
--- a/Admin Plugins/Auditor/Admin/AuditRuleItemManager.cs
+++ b/Admin Plugins/Auditor/Admin/AuditRuleItemManager.cs
@@ -189,6 +189,9 @@ namespace Auditor.Admin
             CurrentItem.Properties["TriggerExport"] = "Yes";
             CurrentItem.Properties["TriggerIndependentPlayback"] = "Yes";
             CurrentItem.Properties["Enabled"] = "Yes";
+            CurrentItem.Properties["SpecifyCameras"] = "No";
+            CurrentItem.Properties["CameraIds"] = "";
+            CurrentItem.Properties["CameraNames"] = "";
 
             if (_userControl != null)
                 _userControl.FillContent(CurrentItem);

--- a/Admin Plugins/Auditor/Admin/AuditRuleUserControl.cs
+++ b/Admin Plugins/Auditor/Admin/AuditRuleUserControl.cs
@@ -6,6 +6,7 @@ using System.Threading;
 using System.Windows.Forms;
 using VideoOS.Platform;
 using VideoOS.Platform.ConfigurationItems;
+using VideoOS.Platform.UI;
 
 namespace Auditor.Admin
 {
@@ -34,6 +35,14 @@ namespace Auditor.Admin
         private CheckBox _chkEnabled;
 
         private List<string> _allUsers = new List<string>();
+        private CheckBox _chkSpecifyCameras;
+        private Label _lblSpecifyCamerasDesc;
+        private GroupBox _grpCameras;
+        private ListBox _lstCameras;
+        private Button _btnAddCamera;
+        private Button _btnRemoveCamera;
+        private List<(Guid Id, string Name)> _selectedCameras = new List<(Guid, string)>();
+
         private bool _filling;
         private readonly PluginLog _log = new PluginLog("Admin Auditor - AuditRule UC");
 
@@ -42,6 +51,7 @@ namespace Auditor.Admin
         public AuditRuleUserControl()
         {
             InitializeComponent();
+            SetupCameraControls();
             _txtName.TextChanged += OnUserChange;
             _btnRefresh.Click += OnBtnRefreshClick;
             _lstUsers.ItemCheck += OnLstUsersItemCheck;
@@ -346,6 +356,127 @@ namespace Auditor.Admin
 
         }
 
+        private void SetupCameraControls()
+        {
+            _grpCameras = new GroupBox
+            {
+                Location = new System.Drawing.Point(15, 220),
+                Size = new System.Drawing.Size(458, 40),
+                TabIndex = 10,
+                TabStop = false,
+                Text = "Camera Selection",
+            };
+
+            _chkSpecifyCameras = new CheckBox
+            {
+                AutoSize = true,
+                Location = new System.Drawing.Point(10, 22),
+                Text = "Specify Cameras",
+                TabIndex = 0,
+            };
+
+            _lblSpecifyCamerasDesc = new Label
+            {
+                AutoSize = true,
+                ForeColor = System.Drawing.SystemColors.ControlDarkDark,
+                Location = new System.Drawing.Point(27, 42),
+                Text = "When enabled, auditing only applies to the listed cameras.",
+                TabIndex = 1,
+            };
+
+            _lstCameras = new ListBox
+            {
+                Location = new System.Drawing.Point(10, 62),
+                Size = new System.Drawing.Size(438, 90),
+                TabIndex = 2,
+            };
+
+            _btnAddCamera = new Button
+            {
+                Location = new System.Drawing.Point(10, 155),
+                Size = new System.Drawing.Size(100, 23),
+                Text = "Add Camera...",
+                TabIndex = 3,
+            };
+
+            _btnRemoveCamera = new Button
+            {
+                Location = new System.Drawing.Point(116, 155),
+                Size = new System.Drawing.Size(70, 23),
+                Text = "Remove",
+                TabIndex = 4,
+            };
+
+            _grpCameras.Controls.Add(_chkSpecifyCameras);
+            _grpCameras.Controls.Add(_lblSpecifyCamerasDesc);
+            _grpCameras.Controls.Add(_lstCameras);
+            _grpCameras.Controls.Add(_btnAddCamera);
+            _grpCameras.Controls.Add(_btnRemoveCamera);
+
+            Controls.Add(_grpCameras);
+
+            _chkSpecifyCameras.CheckedChanged += OnSpecifyCamerasChanged;
+            _btnAddCamera.Click += OnBtnAddCameraClick;
+            _btnRemoveCamera.Click += OnBtnRemoveCameraClick;
+
+            UpdateCameraGroupLayout();
+        }
+
+        private void UpdateCameraGroupLayout()
+        {
+            bool expanded = _chkSpecifyCameras.Checked;
+            _lblSpecifyCamerasDesc.Visible = expanded;
+            _lstCameras.Visible = expanded;
+            _btnAddCamera.Visible = expanded;
+            _btnRemoveCamera.Visible = expanded;
+            _grpCameras.Height = expanded ? 185 : 45;
+
+            _grpReasonPrompts.Top = _grpCameras.Bottom + 9;
+            _grpEventTriggers.Top = _grpReasonPrompts.Bottom + 9;
+            _chkEnabled.Top = _grpEventTriggers.Bottom + 11;
+            this.Height = _chkEnabled.Bottom + 15;
+        }
+
+        private void OnSpecifyCamerasChanged(object sender, EventArgs e)
+        {
+            UpdateCameraGroupLayout();
+            if (!_filling)
+                ConfigurationChangedByUser?.Invoke(this, EventArgs.Empty);
+        }
+
+        private void OnBtnAddCameraClick(object sender, EventArgs e)
+        {
+            var form = new ItemPickerWpfWindow
+            {
+                Items = Configuration.Instance.GetItemsByKind(Kind.Camera),
+                KindsFilter = new List<Guid> { Kind.Camera },
+                SelectionMode = SelectionModeOptions.AutoCloseOnSelect,
+            };
+
+            if (form.ShowDialog() == true && form.SelectedItems != null && form.SelectedItems.Any())
+            {
+                var selected = form.SelectedItems.First();
+                var id = selected.FQID.ObjectId;
+                if (!_selectedCameras.Any(c => c.Id == id))
+                {
+                    _selectedCameras.Add((id, selected.Name));
+                    _lstCameras.Items.Add(selected.Name);
+                    OnUserChange(sender, e);
+                }
+            }
+        }
+
+        private void OnBtnRemoveCameraClick(object sender, EventArgs e)
+        {
+            var idx = _lstCameras.SelectedIndex;
+            if (idx >= 0)
+            {
+                _selectedCameras.RemoveAt(idx);
+                _lstCameras.Items.RemoveAt(idx);
+                OnUserChange(sender, e);
+            }
+        }
+
         private void LoadUsersAsync()
         {
             _btnRefresh.Enabled = false;
@@ -479,6 +610,32 @@ namespace Auditor.Admin
                 _chkTriggerExport.Checked = !item.Properties.ContainsKey("TriggerExport") || item.Properties["TriggerExport"] == "Yes";
                 _chkTriggerIndependentPlayback.Checked = !item.Properties.ContainsKey("TriggerIndependentPlayback") || item.Properties["TriggerIndependentPlayback"] == "Yes";
                 _chkEnabled.Checked = !item.Properties.ContainsKey("Enabled") || item.Properties["Enabled"] == "Yes";
+
+                // Camera selection
+                _chkSpecifyCameras.Checked = item.Properties.ContainsKey("SpecifyCameras") && item.Properties["SpecifyCameras"] == "Yes";
+
+                _selectedCameras.Clear();
+                _lstCameras.Items.Clear();
+                var cameraIds = item.Properties.ContainsKey("CameraIds") ? item.Properties["CameraIds"] : "";
+                var cameraNames = item.Properties.ContainsKey("CameraNames") ? item.Properties["CameraNames"] : "";
+                var ids = cameraIds.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                var names = cameraNames.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+                for (int i = 0; i < ids.Length; i++)
+                {
+                    if (Guid.TryParse(ids[i].Trim(), out var camId))
+                    {
+                        var camName = i < names.Length ? names[i].Trim() : "(unknown)";
+                        try
+                        {
+                            var camItem = Configuration.Instance.GetItem(camId, Kind.Camera);
+                            if (camItem != null) camName = camItem.Name;
+                        }
+                        catch { }
+                        _selectedCameras.Add((camId, camName));
+                        _lstCameras.Items.Add(camName);
+                    }
+                }
+                UpdateCameraGroupLayout();
             }
             finally
             {
@@ -502,6 +659,11 @@ namespace Auditor.Admin
                 _chkTriggerExport.Checked = true;
                 _chkTriggerIndependentPlayback.Checked = true;
                 _chkEnabled.Checked = true;
+
+                _chkSpecifyCameras.Checked = false;
+                _selectedCameras.Clear();
+                _lstCameras.Items.Clear();
+                UpdateCameraGroupLayout();
             }
             finally
             {
@@ -529,6 +691,19 @@ namespace Auditor.Admin
             item.Properties["TriggerExport"] = _chkTriggerExport.Checked ? "Yes" : "No";
             item.Properties["TriggerIndependentPlayback"] = _chkTriggerIndependentPlayback.Checked ? "Yes" : "No";
             item.Properties["Enabled"] = _chkEnabled.Checked ? "Yes" : "No";
+
+            // Auto-disable camera filter when list is empty
+            var specifyCameras = _chkSpecifyCameras.Checked && _selectedCameras.Count > 0;
+            if (_chkSpecifyCameras.Checked && _selectedCameras.Count == 0)
+            {
+                _filling = true;
+                _chkSpecifyCameras.Checked = false;
+                UpdateCameraGroupLayout();
+                _filling = false;
+            }
+            item.Properties["SpecifyCameras"] = specifyCameras ? "Yes" : "No";
+            item.Properties["CameraIds"] = string.Join(";", _selectedCameras.Select(c => c.Id.ToString()));
+            item.Properties["CameraNames"] = string.Join(";", _selectedCameras.Select(c => c.Name));
         }
     }
 }

--- a/Admin Plugins/Auditor/Admin/HelpPage.html
+++ b/Admin Plugins/Auditor/Admin/HelpPage.html
@@ -167,6 +167,21 @@
     </div>
 
     <div class="card">
+        <h2>Camera Selection</h2>
+        <p>
+            By default, audit rules apply to <strong>all cameras</strong>. To restrict a rule
+            to specific cameras, enable the <strong>Specify Cameras</strong> checkbox and add
+            cameras using the camera picker. When enabled, reason prompts and event triggers
+            will only fire when the user interacts with one of the listed cameras.
+        </p>
+        <ul>
+            <li><strong>Playback</strong> &ndash; triggered only if a specified camera is in the current view</li>
+            <li><strong>Export</strong> &ndash; triggered only if a specified camera is in the current view</li>
+            <li><strong>Independent Playback</strong> &ndash; triggered only for the specific camera</li>
+        </ul>
+    </div>
+
+    <div class="card">
         <h2>Reason Prompts (Audit Log)</h2>
         <p>When enabled, the user is shown a dialog and must enter a reason. The reason is written to the Milestone system audit log.</p>
         <ul>

--- a/Admin Plugins/Auditor/Client/AuditorBackgroundPlugin.cs
+++ b/Admin Plugins/Auditor/Client/AuditorBackgroundPlugin.cs
@@ -34,6 +34,8 @@ namespace Auditor.Client
 
         // Audit rule config - cached matched rule for current user
         private Item _cachedRule;
+        private bool _cachedSpecifyCameras;
+        private HashSet<Guid> _cachedCameraIds = new HashSet<Guid>();
 
         private static readonly PluginLog _log = new PluginLog("SC Auditor");
         private readonly CrossMessageHandler _cmh = new CrossMessageHandler(_log);
@@ -104,8 +106,25 @@ namespace Auditor.Client
 
                 _cachedRule = matched;
 
+                _cachedCameraIds.Clear();
+                _cachedSpecifyCameras = false;
                 if (matched != null)
-                    _log.Info($"Matched audit rule '{matched.Name}' for user '{currentUser}'");
+                {
+                    _cachedSpecifyCameras = matched.Properties.ContainsKey("SpecifyCameras") && matched.Properties["SpecifyCameras"] == "Yes";
+                    if (_cachedSpecifyCameras)
+                    {
+                        var cameraIds = matched.Properties.ContainsKey("CameraIds") ? matched.Properties["CameraIds"] : "";
+                        foreach (var idStr in cameraIds.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries))
+                        {
+                            if (Guid.TryParse(idStr.Trim(), out var id))
+                                _cachedCameraIds.Add(id);
+                        }
+                    }
+                }
+
+                if (matched != null)
+                    _log.Info($"Matched audit rule '{matched.Name}' for user '{currentUser}'" +
+                        (_cachedSpecifyCameras ? $" (cameras: {_cachedCameraIds.Count})" : " (all cameras)"));
                 else
                     _log.Info($"No matching audit rule for user '{currentUser ?? "(unknown)"}'");
             }
@@ -180,6 +199,49 @@ namespace Auditor.Client
             return null;
         }
 
+        #region Camera Filtering
+
+        private List<Guid> GetAllCameraIdsInView()
+        {
+            var ids = new List<Guid>();
+            lock (_imageViewers)
+            {
+                foreach (var viewer in _imageViewers)
+                {
+                    try
+                    {
+                        if (viewer.CameraFQID != null && !ids.Contains(viewer.CameraFQID.ObjectId))
+                            ids.Add(viewer.CameraFQID.ObjectId);
+                    }
+                    catch { }
+                }
+            }
+            return ids;
+        }
+
+        private bool ShouldAuditForCameras()
+        {
+            if (!_cachedSpecifyCameras) return true;
+            if (_cachedCameraIds.Count == 0) return false;
+
+            var idsInView = GetAllCameraIdsInView();
+            foreach (var id in idsInView)
+            {
+                if (_cachedCameraIds.Contains(id))
+                    return true;
+            }
+            return false;
+        }
+
+        private bool ShouldAuditForCamera(FQID cameraFqid)
+        {
+            if (!_cachedSpecifyCameras) return true;
+            if (cameraFqid == null) return true;
+            return _cachedCameraIds.Contains(cameraFqid.ObjectId);
+        }
+
+        #endregion
+
         #region Mode Changed
 
         private string _pendingMode;
@@ -244,8 +306,9 @@ namespace Auditor.Client
                 _log.Info("Mode changed to Playback");
                 var rule = _cachedRule;
                 string reason = null;
-                bool promptEnabled = rule != null && (!rule.Properties.ContainsKey("PromptPlayback") || rule.Properties["PromptPlayback"] == "Yes");
-                bool triggerEnabled = rule != null && (!rule.Properties.ContainsKey("TriggerPlayback") || rule.Properties["TriggerPlayback"] == "Yes");
+                bool camerasMatch = rule != null && ShouldAuditForCameras();
+                bool promptEnabled = camerasMatch && (!rule.Properties.ContainsKey("PromptPlayback") || rule.Properties["PromptPlayback"] == "Yes");
+                bool triggerEnabled = camerasMatch && (!rule.Properties.ContainsKey("TriggerPlayback") || rule.Properties["TriggerPlayback"] == "Yes");
                 if (promptEnabled)
                 {
                     _log.Info("Showing playback reason prompt (rule matched)");
@@ -325,8 +388,9 @@ namespace Auditor.Client
                 _log.Info("Entered Export workspace");
                 var rule = _cachedRule;
                 string reason = null;
-                bool promptEnabled = rule != null && (!rule.Properties.ContainsKey("PromptExport") || rule.Properties["PromptExport"] == "Yes");
-                bool triggerEnabled = rule != null && (!rule.Properties.ContainsKey("TriggerExport") || rule.Properties["TriggerExport"] == "Yes");
+                bool camerasMatch = rule != null && ShouldAuditForCameras();
+                bool promptEnabled = camerasMatch && (!rule.Properties.ContainsKey("PromptExport") || rule.Properties["PromptExport"] == "Yes");
+                bool triggerEnabled = camerasMatch && (!rule.Properties.ContainsKey("TriggerExport") || rule.Properties["TriggerExport"] == "Yes");
                 if (promptEnabled)
                 {
                     _log.Info("Showing export reason prompt (rule matched)");
@@ -388,8 +452,9 @@ namespace Auditor.Client
                 }
                 var rule = _cachedRule;
                 string reason = null;
-                bool promptEnabled = rule != null && (!rule.Properties.ContainsKey("PromptIndependentPlayback") || rule.Properties["PromptIndependentPlayback"] == "Yes");
-                bool triggerEnabled = rule != null && (!rule.Properties.ContainsKey("TriggerIndependentPlayback") || rule.Properties["TriggerIndependentPlayback"] == "Yes");
+                bool camerasMatch = rule != null && ShouldAuditForCamera(viewer.CameraFQID);
+                bool promptEnabled = camerasMatch && (!rule.Properties.ContainsKey("PromptIndependentPlayback") || rule.Properties["PromptIndependentPlayback"] == "Yes");
+                bool triggerEnabled = camerasMatch && (!rule.Properties.ContainsKey("TriggerIndependentPlayback") || rule.Properties["TriggerIndependentPlayback"] == "Yes");
                 if (promptEnabled)
                 {
                     _log.Info("Showing independent playback reason prompt (rule matched)");

--- a/Admin Plugins/Auditor/README.md
+++ b/Admin Plugins/Auditor/README.md
@@ -5,6 +5,7 @@ Audit user access to recorded video in Milestone XProtect. Tracks playback mode 
 ## Features
 
 - Per-user audit rules configured in the Management Client
+- **Camera Selection** - optionally restrict audit rules to specific cameras
 - **Reason Prompts** - force users to provide a reason, written to the Milestone audit log
 - **Event Triggers** - fire XProtect analytics events for use in rules, alarms, and notifications
 - Reason prompts and event triggers are independently configurable per activity
@@ -27,8 +28,13 @@ Restart the Smart Client, Management Client, and Event Server.
 2. Navigate to the **Auditor** node in the sidebar
 3. Create a new **Audit Rule**
 4. Give the rule a name and select the users to monitor
-5. Configure which reason prompts and event triggers to enable
-6. Save the rule
+5. Optionally enable **Specify Cameras** to restrict the rule to specific cameras
+6. Configure which reason prompts and event triggers to enable
+7. Save the rule
+
+## Camera Selection
+
+By default, audit rules apply to all cameras. Enable **Specify Cameras** on a rule to restrict it to specific cameras. When enabled, reason prompts and event triggers only fire when the user interacts with one of the listed cameras.
 
 ## Reason Prompts (Audit Log)
 

--- a/docs/plugins/admin/auditor.md
+++ b/docs/plugins/admin/auditor.md
@@ -9,12 +9,20 @@ Audit user access to recorded video in XProtect. Tracks playback mode changes, e
 1. Open the **Management Client**
 2. Navigate to the **Auditor** node in the sidebar
 3. Create a new **Audit Rule**
-4. Give the rule a name, select users to monitor, configure reason prompts and event triggers
-5. Save the rule
+4. Give the rule a name, select users to monitor
+5. Optionally enable **Specify Cameras** to restrict the rule to specific cameras
+6. Configure reason prompts and event triggers
+7. Save the rule
 
 <video controls width="100%">
   <source src="../vids/auditor.mp4" type="video/mp4">
 </video>
+
+## Camera Selection
+
+By default, audit rules apply to **all cameras**. To restrict a rule to specific cameras, enable the **Specify Cameras** checkbox and add cameras using the camera picker.
+
+When enabled, reason prompts and event triggers only fire when the user interacts with one of the listed cameras.
 
 ## Reason Prompts (Audit Log)
 
@@ -56,5 +64,6 @@ The plugin runs across three environments:
 | Reason prompt not showing | Check that the user matches a rule with the relevant reason prompt enabled |
 | Events not in alarm list | Verify the Event Server is running and the plugin is loaded |
 | Audit log entries missing | Ensure reason prompts are enabled - audit log entries are only written when a reason is provided |
+| Rule not triggering for specific cameras | If **Specify Cameras** is enabled, verify the relevant cameras are added to the rule's camera list |
 
 </div>


### PR DESCRIPTION
Introduce optional camera filtering for audit rules. Admin: add Specify Cameras checkbox, camera picker/list (add/remove), persist new properties (SpecifyCameras, CameraIds, CameraNames), default values, UI layout/validation (auto-disable when list empty) and load/save handling.