### PR TITLE
ci(scorecard): pass SCORECARD_TOKEN for Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Fine-grained PAT with "Administration: read" on this repo, stored as
+          # the SCORECARD_TOKEN secret. The default GITHUB_TOKEN cannot read
+          # branch-protection settings, so without this the Branch-Protection
+          # check scores 0 even when protection is configured.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           # Publish results to the OpenSSF REST API so the badge resolves.
           publish_results: true
 


### PR DESCRIPTION
## What

Scorecard's **Branch-Protection** check needs to read the repo's protection settings, but the default `GITHUB_TOKEN` can't. This passes a fine-grained PAT via `repo_token: ${{ secrets.SCORECARD_TOKEN }}` so the check can score properly.

## Required secret (create before this helps)

Create a **fine-grained PAT** limited to `Cacsjep/mscp` with:
- **Administration: Read-only** (read branch protection / rulesets)
- **Contents: Read-only**

Add it as repo secret **`SCORECARD_TOKEN`** (Settings -> Secrets and variables -> Actions). If the secret is missing the workflow still runs, just without the elevated read.

## Side benefit

Opening this PR triggers **PR Build**, so its `ci-success` check reports against a PR targeting `main` and becomes selectable as a required status check in the branch ruleset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)