### PR TITLE
ci(release): cosign-sign SHA-256 checksums for Signed-Releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -266,10 +266,41 @@ jobs:
             MSCPlugins-*-Setup.msi
             *-${{ github.ref_name }}.zip
 
+      # SHA-256 checksums of every release artifact, signed with cosign
+      # (keyless, using the job's OIDC token). Scorecard's Signed-Releases
+      # check looks for a signature asset on the release; checksums.txt.sig
+      # satisfies it, and users can verify their downloads against it.
+      - name: Generate SHA-256 checksums
+        shell: pwsh
+        run: |
+          $files = Get-ChildItem -File | Where-Object {
+            $_.Name -like "*-${{ github.ref_name }}.zip" -or $_.Name -like "MSCPlugins-*-Setup.msi"
+          }
+          $lines = foreach ($f in ($files | Sort-Object Name)) {
+            $hash = (Get-FileHash -Algorithm SHA256 -LiteralPath $f.FullName).Hash.ToLower()
+            "$hash  $($f.Name)"
+          }
+          $lines | Set-Content -Encoding ascii checksums.txt
+          Get-Content checksums.txt
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+
+      - name: Sign checksums with cosign (keyless)
+        shell: pwsh
+        run: |
+          cosign sign-blob --yes checksums.txt `
+            --output-signature checksums.txt.sig `
+            --output-certificate checksums.txt.pem
+          if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             *-${{ github.ref_name }}.zip
             MSCPlugins-*-Setup.msi
+            checksums.txt
+            checksums.txt.sig
+            checksums.txt.pem
           generate_release_notes: true


### PR DESCRIPTION
## Why

`actions/attest-build-provenance` stores a GitHub attestation but does **not** attach a signature file to the release. Scorecard's **Signed-Releases** check only inspects **release assets** for a signature/provenance file, so it reported every release as unsigned (0/10) even though the attestation exists.

## What

In the release job, after the artifacts are built:
1. Generate `checksums.txt` (SHA-256 of every ZIP + the MSI).
2. `cosign sign-blob` it **keyless** via the job's OIDC token (the job already has `id-token: write`).
3. Upload `checksums.txt`, `checksums.txt.sig`, `checksums.txt.pem` as release assets.

Scorecard detects the `.sig` and counts the release as signed; users also get checksums to verify downloads. The `attest-build-provenance` step is kept (better for `gh attestation verify`).

## Notes

- Score ramps over the next ~5 releases (Scorecard scores the fraction of recent releases that are signed), not instantly to 10.
- Worth a `d*` dev tag first is not needed here (dev workflow unchanged), but the next `v*` release will exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)