### PR TITLE
fix(FlexView): copy federated views via the configuration API

### DIFF
--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -79,8 +79,27 @@ namespace FlexView.Client
             public ServerId ServerId;
         }
 
+        // Session-long cache: the walk costs real seconds even after skipping the master's wasted
+        // config-plane read (still several seconds per child site over the network), and views rarely
+        // change site-to-site within a single Smart Client session. Cached until ForceRefresh clears
+        // it (wired to a Refresh button in ViewBrowserWindow) - there's no automatic expiry, by design
+        // (the user asked for session-long caching with a manual refresh, not a time-based one).
+        // Guarded by a lock since CollectAllSiteViews runs on a background thread.
+        private static readonly object _cacheLock = new object();
+        private static List<SiteViews> _cache;
+
+        public static void ForceRefresh()
+        {
+            lock (_cacheLock) { _cache = null; }
+        }
+
         public static List<SiteViews> CollectAllSiteViews()
         {
+            lock (_cacheLock)
+            {
+                if (_cache != null) return _cache;
+            }
+
             var log = FlexViewDefinition.Log;
             var result = new List<SiteViews>();
 
@@ -143,6 +162,7 @@ namespace FlexView.Client
                 result.Add(sv);
             }
 
+            lock (_cacheLock) { _cache = result; }
             return result;
         }
 

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -44,11 +44,12 @@ namespace FlexView.Client
             public string LayoutViewItemsXml;
             public bool HasLayoutXml;
 
-            // Per-slot content (confirmed against a real system: LayoutViewItems/AddView only carry
-            // grid geometry - camera assignments live separately on ViewItemChildItems, one per pane,
-            // keyed by ViewItemPosition). Only camera slots are captured for now; other view item
-            // types (maps, HTML, plugins) are left as empty panes on copy.
-            public List<FedViewItem> Items = new List<FedViewItem>();
+            // Used only if/when this view is actually copied - see ReadCameraItems. Deliberately not
+            // read during the browse walk itself: fetching ViewItemChildItems for every view (rather
+            // than just the one the user picks) roughly doubled the walk's cost across a site with
+            // thousands of views, for data the browse tree never displays.
+            public ServerId SourceServerId;
+            public string SourcePath;
         }
 
         // One pane's content, parsed from a ViewItemChildItem's ViewItemDefinitionXml.
@@ -103,24 +104,13 @@ namespace FlexView.Client
                     IsMaster = isMaster
                 };
 
-                // Config-plane read: works for master and every child, off the Management Server.
-                try
-                {
-                    var ms = new ManagementServer(site.Fqid);
-                    var vgf = ms.ViewGroupFolder;
-                    if (vgf?.ViewGroups == null)
-                        log.Info($"[FlexViewFed] [{site.Name}] ViewGroupFolder/ViewGroups is null");
-                    else
-                        foreach (var vg in vgf.ViewGroups)
-                            WalkViewGroup(vg, site.Name, "", sv.FedViews, 0);
-                }
-                catch (Exception ex)
-                {
-                    log.Info($"[FlexViewFed] [{site.Name}] ManagementServer ViewGroup read failed: {ex.GetType().Name}: {ex.Message}");
-                }
-                log.Info($"[FlexViewFed] [{site.Name}] views via ManagementServer config: {sv.FedViews.Count}");
-
-                // Master also keeps its client-runtime roots so same-site Open/edit stays fully working.
+                // Master already has a fully working client-runtime tree (below) - PopulateFederatedTree
+                // renders the master from ClientViewRoots, never FedViews, so walking the master's
+                // config-plane view tree here is pure wasted work. Confirmed against a real system:
+                // that walk alone (3411 views) took ~73 seconds of the ~90 second total load time, for
+                // data that was computed and then never used. Only child sites need the config-plane
+                // walk - they have no working client-session tree at all (that's the original bug this
+                // whole file exists to work around).
                 if (isMaster)
                 {
                     try
@@ -130,6 +120,24 @@ namespace FlexView.Client
                         log.Info($"[FlexViewFed] [{site.Name}] (master) ClientControl roots: {sv.ClientViewRoots.Count}");
                     }
                     catch (Exception ex) { log.Info($"[FlexViewFed] [{site.Name}] GetViewGroupItems failed: {ex.Message}"); }
+                }
+                else
+                {
+                    try
+                    {
+                        var ms = new ManagementServer(site.Fqid);
+                        var vgf = ms.ViewGroupFolder;
+                        if (vgf?.ViewGroups == null)
+                            log.Info($"[FlexViewFed] [{site.Name}] ViewGroupFolder/ViewGroups is null");
+                        else
+                            foreach (var vg in vgf.ViewGroups)
+                                WalkViewGroup(vg, site.Name, "", sv.FedViews, 0);
+                    }
+                    catch (Exception ex)
+                    {
+                        log.Info($"[FlexViewFed] [{site.Name}] ManagementServer ViewGroup read failed: {ex.GetType().Name}: {ex.Message}");
+                    }
+                    log.Info($"[FlexViewFed] [{site.Name}] views via ManagementServer config: {sv.FedViews.Count}");
                 }
 
                 result.Add(sv);
@@ -169,7 +177,14 @@ namespace FlexView.Client
                             LayoutCustomId = SafeGet(() => v.LayoutCustomId),
                             LayoutIcon = SafeGet(() => v.LayoutIcon),
                             LayoutViewItemsXml = xml,
-                            HasLayoutXml = !string.IsNullOrEmpty(xml)
+                            HasLayoutXml = !string.IsNullOrEmpty(xml),
+                            // Cheap - ServerId/Path are already-loaded fields on v, not a network call.
+                            // Used to re-fetch just this one view's ViewItemChildItems later, at copy
+                            // time, instead of every view paying that cost during the browse walk (that
+                            // used to double the walk's cost across thousands of views for no benefit -
+                            // only the one view actually being copied ever needs its camera content).
+                            SourceServerId = SafeGetServerId(() => v.ServerId),
+                            SourcePath = SafeGet(() => v.Path)
                         };
                         acc.Add(fv);
 
@@ -178,37 +193,6 @@ namespace FlexView.Client
                         {
                             var preview = xml.Length > 800 ? xml.Substring(0, 800) + " ...[truncated]" : xml;
                             log.Info($"[FlexViewFed] [{siteName}] sample view '{v.Name}' layoutType={fv.LayoutType} LayoutViewItems=\n{preview}");
-                        }
-
-                        // LayoutViewItems only carries grid geometry - AddView recreates the panes but not
-                        // camera content (confirmed against a real system: copied views come back with
-                        // correct layout, empty slots). Per-slot content lives separately on
-                        // ViewItemChildItems, one per pane, keyed by ViewItemPosition. A camera slot's
-                        // ViewItemDefinitionXml looks like (confirmed from a real dump):
-                        //   <viewitem type="...CameraContentType.CameraViewItem, VideoOS.RemoteClient.Application">
-                        //     <iteminfo cameraid="{guid}" .../>
-                        //   </viewitem>
-                        // Other view item types (maps, HTML, plugins) aren't parsed yet - camera is the
-                        // common case this plugin needs to carry across a federated copy.
-                        try
-                        {
-                            var children = v.ViewItemChildItems;
-                            if (children != null)
-                            {
-                                foreach (var vi in children)
-                                {
-                                    if (vi == null) continue;
-                                    var camId = ParseCameraId(vi.ViewItemDefinitionXml);
-                                    if (camId != null)
-                                        fv.Items.Add(new FedViewItem { Position = vi.ViewItemPosition, CameraId = camId });
-                                }
-                            }
-                            if (acc.Count <= 5)
-                                log.Info($"[FlexViewFed] [{siteName}] view '{v.Name}': {children?.Count ?? 0} view item(s), {fv.Items.Count} camera(s) parsed");
-                        }
-                        catch (Exception ex)
-                        {
-                            log.Info($"[FlexViewFed] [{siteName}] ViewItemChildItems read failed for '{v.Name}': {ex.Message}");
                         }
                     }
                 }
@@ -234,6 +218,48 @@ namespace FlexView.Client
         private static string SafeGet(Func<string> f)
         {
             try { return f() ?? ""; } catch { return ""; }
+        }
+
+        private static ServerId SafeGetServerId(Func<ServerId> f)
+        {
+            try { return f(); } catch { return null; }
+        }
+
+        // Re-fetches ViewItemChildItems for exactly one view - called only when that view is actually
+        // being copied (see FedView.SourceServerId/SourcePath). A camera slot's ViewItemDefinitionXml
+        // looks like (confirmed from a real dump):
+        //   <viewitem type="...CameraContentType.CameraViewItem, VideoOS.RemoteClient.Application">
+        //     <iteminfo cameraid="{guid}" .../>
+        //   </viewitem>
+        // Other view item types (maps, HTML, plugins) aren't parsed yet - camera is the common case
+        // this plugin needs to carry across a federated copy.
+        internal static List<FedViewItem> ReadCameraItems(FedView fv)
+        {
+            var result = new List<FedViewItem>();
+            if (fv?.SourceServerId == null || string.IsNullOrEmpty(fv.SourcePath)) return result;
+
+            var log = FlexViewDefinition.Log;
+            try
+            {
+                var v = new VideoOS.Platform.ConfigurationItems.View(fv.SourceServerId, fv.SourcePath);
+                var children = v.ViewItemChildItems;
+                if (children != null)
+                {
+                    foreach (var vi in children)
+                    {
+                        if (vi == null) continue;
+                        var camId = ParseCameraId(vi.ViewItemDefinitionXml);
+                        if (camId != null)
+                            result.Add(new FedViewItem { Position = vi.ViewItemPosition, CameraId = camId });
+                    }
+                }
+                log.Info($"[FlexViewFed] ReadCameraItems('{fv.Name}'): {children?.Count ?? 0} view item(s), {result.Count} camera(s) parsed");
+            }
+            catch (Exception ex)
+            {
+                log.Info($"[FlexViewFed] ReadCameraItems failed for '{fv.Name}': {ex.Message}");
+            }
+            return result;
         }
 
         // Extracts the camera GUID from a single view item's definition XML, when it's a camera

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -6,25 +6,46 @@ using VideoOS.Platform.ConfigurationItems;
 
 namespace FlexView.Client
 {
-    // TEST / DIAGNOSTIC (federated views): walks the master site and, in a Milestone Federated
-    // Architecture, its child sites, and collects the top-level view-group Items of each site so the
-    // Open dialog can present one merged, per-site tree. Master views come from the proven
-    // ClientControl API; child-site views are discovered by walking the site Item's configuration
-    // children looking for Kind.View roots.
+    // TEST / DIAGNOSTIC (federated views): reads views from the master site and, in a Milestone
+    // Federated Architecture, from its child sites too - straight off each site's Management Server
+    // configuration.
     //
-    // Everything is logged with the [FlexViewFed] prefix so a customer test run can be diagnosed from
-    // MIPLog.txt even when nothing appears in the tree - the log tells us whether child sites were
-    // enumerated at all, what each site exposed, and whether any view items were reachable.
+    // Views persist on the Management Server (ViewGroupFolder -> ViewGroup -> ViewFolder -> View),
+    // exactly like Recording Servers do (RecordingServerFolder -> RecordingServer). So the same
+    // per-site pattern that made System Status federation-aware works here: construct a
+    // ManagementServer from each site's FQID and enumerate its ViewGroupFolder. This is a
+    // configuration-plane read - it does NOT depend on a client session, so it is not subject to the
+    // "Cannot work with View Groups in standalone SDK" limitation that ClientControl hits.
     //
-    // The site-walk (EnumerateSites/CollectSites/SiteRef) is copied from the working federated
-    // System Status implementation so this reuses a proven pattern.
+    // Everything is logged with the [FlexViewFed] prefix (including a sample view's LayoutViewItems
+    // XML) so a customer test run can be diagnosed - and so we capture the layout format needed to
+    // recreate a child-site view on the parent.
     internal static class FederationWalker
     {
+        // A view read from a site's Management Server configuration.
+        internal sealed class FedView
+        {
+            public string SiteName;
+            public string GroupPath;         // "Group / Subgroup"
+            public string Name;
+            public string Id;
+            public string LayoutType;
+            public bool HasLayoutXml;
+            // Client FQID rebuilt from the view's ServerId + Id, so the view can be resolved back to a
+            // ViewAndLayoutItem via Configuration.Instance.GetItem and opened with the normal pipeline.
+            public FQID Fqid;
+        }
+
         internal sealed class SiteViews
         {
-            public string Label;          // e.g. "Master: HQ" or "Site: Branch-1"
-            public List<Item> ViewRoots;  // top-level view-group Items for this site
+            public string Label;                 // "Master: HQ" / "Site: Branch-1"
             public bool IsMaster;
+
+            // Master only: the client-runtime view roots, still used for the working same-site Open.
+            public List<Item> ClientViewRoots = new List<Item>();
+
+            // All sites: views read from the Management Server config (federation-capable proof path).
+            public List<FedView> FedViews = new List<FedView>();
         }
 
         // One site in the (possibly federated) hierarchy: the master or a child site.
@@ -53,118 +74,135 @@ namespace FlexView.Client
             {
                 bool isMaster = masterServerId != null && site.ServerId != null &&
                                 site.ServerId.Id == masterServerId.Id;
-                var roots = new List<Item>();
 
-                // The config-plane walk (Configuration.Instance.GetItem(site.Fqid) -> Kind.View) is
-                // the SAME accessor for master and child, because views persist on each site's
-                // management server, not only in the client runtime. Running it on the master too is
-                // the decisive test: if it finds the master's own views (which we KNOW exist), the
-                // approach is proven and child sites should behave identically.
-                var walked = new List<Item>();
+                var sv = new SiteViews
+                {
+                    Label = (isMaster ? "Master: " : "Site: ") + site.Name,
+                    IsMaster = isMaster
+                };
+
+                // Config-plane read: works for master and every child, off the Management Server.
                 try
                 {
-                    var siteItem = Configuration.Instance.GetItem(site.Fqid);
-                    if (siteItem == null)
-                        log.Info($"[FlexViewFed] [{site.Name}] GetItem(site) returned null - cannot walk views");
+                    var ms = new ManagementServer(site.Fqid);
+                    var vgf = ms.ViewGroupFolder;
+                    if (vgf?.ViewGroups == null)
+                        log.Info($"[FlexViewFed] [{site.Name}] ViewGroupFolder/ViewGroups is null");
                     else
-                        CollectViewRoots(siteItem, site.ServerId, walked, site.Name, new HashSet<Guid>(), 0);
+                        foreach (var vg in vgf.ViewGroups)
+                            WalkViewGroup(vg, site.Name, "", sv.FedViews, 0);
                 }
                 catch (Exception ex)
                 {
-                    log.Info($"[FlexViewFed] [{site.Name}] config-walk failed: {ex.Message}");
+                    log.Info($"[FlexViewFed] [{site.Name}] ManagementServer ViewGroup read failed: {ex.GetType().Name}: {ex.Message}");
                 }
-                log.Info($"[FlexViewFed] [{site.Name}] config-walk (GetItem+Kind.View) roots: {walked.Count}");
+                log.Info($"[FlexViewFed] [{site.Name}] views via ManagementServer config: {sv.FedViews.Count}");
 
+                // Master also keeps its client-runtime roots so same-site Open/edit stays fully working.
                 if (isMaster)
                 {
-                    // Baseline comparison: the known-good client accessor. If the config-walk count
-                    // matches this, the config-plane path is confirmed equivalent on the master.
-                    int clientCount = -1;
                     try
                     {
                         var groups = ClientControl.Instance.GetViewGroupItems();
-                        clientCount = groups?.Count ?? 0;
+                        if (groups != null) sv.ClientViewRoots.AddRange(groups);
+                        log.Info($"[FlexViewFed] [{site.Name}] (master) ClientControl roots: {sv.ClientViewRoots.Count}");
                     }
                     catch (Exception ex) { log.Info($"[FlexViewFed] [{site.Name}] GetViewGroupItems failed: {ex.Message}"); }
-                    log.Info($"[FlexViewFed] [{site.Name}] (master) ClientControl baseline: {clientCount} group(s) vs config-walk {walked.Count}");
-
-                    // Use whichever accessor actually produced roots so the Open tree still works today:
-                    // prefer the proven config-walk, fall back to ClientControl if it found nothing.
-                    if (walked.Count > 0)
-                        roots.AddRange(walked);
-                    else
-                    {
-                        try
-                        {
-                            var groups = ClientControl.Instance.GetViewGroupItems();
-                            if (groups != null) roots.AddRange(groups);
-                            log.Info($"[FlexViewFed] [{site.Name}] config-walk empty on master - using ClientControl ({roots.Count}).");
-                        }
-                        catch { }
-                    }
-                }
-                else
-                {
-                    roots.AddRange(walked);
                 }
 
-                result.Add(new SiteViews
-                {
-                    Label = (isMaster ? "Master: " : "Site: ") + site.Name,
-                    ViewRoots = roots,
-                    IsMaster = isMaster
-                });
+                result.Add(sv);
             }
 
             return result;
         }
 
-        // DFS from a site Item collecting the top-most Kind.View items. Descent stops once a Kind.View
-        // item is found on a branch (the browser recurses into it via GetChildren), and never crosses
-        // into a nested child site (a different ServerId) - those are separate site entries. Shallow
-        // levels are logged so we can see exactly what each site exposes.
-        private static void CollectViewRoots(Item node, ServerId siteServerId, List<Item> roots,
-                                             string siteName, HashSet<Guid> seen, int depth)
+        // Recurse a ViewGroup: collect its Views, then descend into nested ViewGroups. The first view
+        // encountered has its LayoutViewItems XML dumped (truncated) so we capture the layout format.
+        private static void WalkViewGroup(VideoOS.Platform.ConfigurationItems.ViewGroup vg, string siteName, string parentPath, List<FedView> acc, int depth)
         {
-            if (node?.FQID == null || depth > 6) return;
-            if (!seen.Add(node.FQID.ObjectId)) return;
+            if (vg == null || depth > 8) return;
+            var log = FlexViewDefinition.Log;
 
-            List<Item> kids = null;
-            try { kids = node.GetChildren(); }
+            string path = string.IsNullOrEmpty(parentPath) ? vg.Name : parentPath + " / " + vg.Name;
+
+            try
+            {
+                var vf = vg.ViewFolder;
+                if (vf?.Views != null)
+                {
+                    foreach (var v in vf.Views)
+                    {
+                        if (v == null) continue;
+                        string xml = null;
+                        try { xml = v.LayoutViewItems; } catch { }
+
+                        var fv = new FedView
+                        {
+                            SiteName = siteName,
+                            GroupPath = path,
+                            Name = v.Name,
+                            Id = v.Id,
+                            LayoutType = SafeGet(() => v.ViewLayoutType),
+                            HasLayoutXml = !string.IsNullOrEmpty(xml),
+                            Fqid = BuildViewFqid(v)
+                        };
+                        acc.Add(fv);
+
+                        // Dump the first view's layout so we know the XML shape for recreation.
+                        if (acc.Count == 1 && !string.IsNullOrEmpty(xml))
+                        {
+                            var preview = xml.Length > 800 ? xml.Substring(0, 800) + " ...[truncated]" : xml;
+                            log.Info($"[FlexViewFed] [{siteName}] sample view '{v.Name}' layoutType={fv.LayoutType} LayoutViewItems=\n{preview}");
+                        }
+                    }
+                }
+            }
             catch (Exception ex)
             {
-                FlexViewDefinition.Log.Info($"[FlexViewFed] [{siteName}] GetChildren failed at d{depth} on '{node.Name}': {ex.Message}");
-                return;
+                log.Info($"[FlexViewFed] [{siteName}] ViewFolder read failed under '{path}': {ex.Message}");
             }
-            if (kids == null) return;
 
-            foreach (var k in kids)
+            try
             {
-                if (k?.FQID == null) continue;
-
-                // A nested child site (different ServerId) is its own entry - do not descend.
-                if (k.FQID.ServerId != null && siteServerId != null && k.FQID.ServerId.Id != siteServerId.Id)
-                    continue;
-
-                if (depth <= 2)
-                    FlexViewDefinition.Log.Info($"[FlexViewFed] [{siteName}] d{depth} child: name='{k.Name}' kind={k.FQID.Kind} folder={k.FQID.FolderType}");
-
-                if (k.FQID.Kind == Kind.View)
-                {
-                    roots.Add(k);   // top-most view item on this branch; browser recurses into it
-                    continue;
-                }
-
-                CollectViewRoots(k, siteServerId, roots, siteName, seen, depth + 1);
+                var nested = vg.ViewGroupFolder;
+                if (nested?.ViewGroups != null)
+                    foreach (var child in nested.ViewGroups)
+                        WalkViewGroup(child, siteName, path, acc, depth + 1);
+            }
+            catch (Exception ex)
+            {
+                log.Info($"[FlexViewFed] [{siteName}] nested ViewGroupFolder read failed under '{path}': {ex.Message}");
             }
         }
 
-        // ── Proven federated site-walk (copied from System Status) ─────────────────────────────
+        private static string SafeGet(Func<string> f)
+        {
+            try { return f() ?? ""; } catch { return ""; }
+        }
 
-        // The raw site walk can surface FQIDs that are not genuine Management Servers (e.g. a
-        // Recording Server's own FQID that appears as a distinct ServerId). Keep only entries whose
-        // Management Server configuration is actually readable - probing RecordingServerFolder throws
-        // for anything that is not a real Management Server. Same filter as System Status.
+        // Rebuild a client FQID for a view from its config ServerId + Id, so it can be resolved back
+        // to a ViewAndLayoutItem with Configuration.Instance.GetItem - the same trick used to resolve
+        // a camera FQID elsewhere. Returns null if the id/server is not usable.
+        private static FQID BuildViewFqid(VideoOS.Platform.ConfigurationItems.View v)
+        {
+            try
+            {
+                if (v?.ServerId == null || string.IsNullOrEmpty(v.Id)) return null;
+                if (!Guid.TryParse(v.Id, out var objId)) return null;
+                return new FQID(v.ServerId, Guid.Empty, objId, FolderType.No, Kind.View);
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] BuildViewFqid failed for '{v?.Name}': {ex.Message}");
+                return null;
+            }
+        }
+
+        // ── Federated site enumeration (proven pattern from System Status) ─────────────────────
+
+        // Keep only entries whose Management Server configuration is actually readable: the raw walk
+        // can surface a Recording Server's own FQID as a distinct ServerId, and probing
+        // RecordingServerFolder throws for anything that is not a real Management Server.
         private static List<SiteRef> EnumerateManagementServers()
         {
             var log = FlexViewDefinition.Log;
@@ -178,12 +216,11 @@ namespace FlexView.Client
                 try
                 {
                     var management = new ManagementServer(s.Fqid);
-                    var _ = management.RecordingServerFolder?.RecordingServers; // throws if not a real MS
+                    var probe = management.RecordingServerFolder?.RecordingServers; // throws if not a real MS
                     result.Add(s);
                 }
                 catch (Exception ex)
                 {
-                    // Not a genuine Management Server (e.g. a Recording Server's own FQID) - excluded.
                     log.Info($"[FlexViewFed] Excluded non-management-server site '{s.Name}': {ex.GetType().Name}");
                 }
             }

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -59,6 +59,18 @@ namespace FlexView.Client
             public Guid? CameraId;
         }
 
+        // A client Item plus its already-fetched children, built once while the site is walked.
+        // ViewBrowserWindow used to call Item.GetChildren() itself, live, to build the master's tree
+        // on every single Open View click - that recursive fetch across ~113+ view groups was the
+        // remaining ~10 second cost even after CollectAllSiteViews itself became a cache hit. Caching
+        // the resolved children here means rebuilding the on-screen tree from a cache hit is pure
+        // in-memory recursion, no network calls at all.
+        internal sealed class ClientNode
+        {
+            public Item Item;
+            public List<ClientNode> Children = new List<ClientNode>();
+        }
+
         internal sealed class SiteViews
         {
             public string Label;                 // "Master: HQ" / "Site: Branch-1"
@@ -66,6 +78,9 @@ namespace FlexView.Client
 
             // Master only: the client-runtime view roots, still used for the working same-site Open.
             public List<Item> ClientViewRoots = new List<Item>();
+
+            // Master only: same roots, pre-expanded - see ClientNode.
+            public List<ClientNode> ClientTree = new List<ClientNode>();
 
             // All sites: views read from the Management Server config (federation-capable proof path).
             public List<FedView> FedViews = new List<FedView>();
@@ -135,7 +150,12 @@ namespace FlexView.Client
                     try
                     {
                         var groups = ClientControl.Instance.GetViewGroupItems();
-                        if (groups != null) sv.ClientViewRoots.AddRange(groups);
+                        if (groups != null)
+                        {
+                            sv.ClientViewRoots.AddRange(groups);
+                            foreach (var g in groups)
+                                sv.ClientTree.Add(BuildClientNode(g, 0));
+                        }
                         log.Info($"[FlexViewFed] [{site.Name}] (master) ClientControl roots: {sv.ClientViewRoots.Count}");
                     }
                     catch (Exception ex) { log.Info($"[FlexViewFed] [{site.Name}] GetViewGroupItems failed: {ex.Message}"); }
@@ -164,6 +184,26 @@ namespace FlexView.Client
 
             lock (_cacheLock) { _cache = result; }
             return result;
+        }
+
+        // Recurse a client Item's children once, up front, so ViewBrowserWindow never has to call
+        // GetChildren() itself when rebuilding the tree from a cache hit.
+        private static ClientNode BuildClientNode(Item item, int depth)
+        {
+            var node = new ClientNode { Item = item };
+            if (item == null || depth > 12) return node;
+
+            bool isFolder;
+            try { isFolder = item.FQID.FolderType != FolderType.No; } catch { isFolder = false; }
+            if (!isFolder) return node;
+
+            List<Item> children = null;
+            try { children = (item as ConfigItem)?.GetChildren(); } catch { }
+            if (children == null) return node;
+
+            foreach (var child in children)
+                node.Children.Add(BuildClientNode(child, depth + 1));
+            return node;
         }
 
         // Recurse a ViewGroup: collect its Views, then descend into nested ViewGroups. The first view

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using VideoOS.Platform;
+using VideoOS.Platform.Client;
+using VideoOS.Platform.ConfigurationItems;
+
+namespace FlexView.Client
+{
+    // TEST / DIAGNOSTIC (federated views): walks the master site and, in a Milestone Federated
+    // Architecture, its child sites, and collects the top-level view-group Items of each site so the
+    // Open dialog can present one merged, per-site tree. Master views come from the proven
+    // ClientControl API; child-site views are discovered by walking the site Item's configuration
+    // children looking for Kind.View roots.
+    //
+    // Everything is logged with the [FlexViewFed] prefix so a customer test run can be diagnosed from
+    // MIPLog.txt even when nothing appears in the tree - the log tells us whether child sites were
+    // enumerated at all, what each site exposed, and whether any view items were reachable.
+    //
+    // The site-walk (EnumerateSites/CollectSites/SiteRef) is copied from the working federated
+    // System Status implementation so this reuses a proven pattern.
+    internal static class FederationWalker
+    {
+        internal sealed class SiteViews
+        {
+            public string Label;          // e.g. "Master: HQ" or "Site: Branch-1"
+            public List<Item> ViewRoots;  // top-level view-group Items for this site
+            public bool IsMaster;
+        }
+
+        // One site in the (possibly federated) hierarchy: the master or a child site.
+        private sealed class SiteRef
+        {
+            public string Name;
+            public FQID Fqid;
+            public ServerId ServerId;
+        }
+
+        public static List<SiteViews> CollectAllSiteViews()
+        {
+            var log = FlexViewDefinition.Log;
+            var result = new List<SiteViews>();
+
+            List<SiteRef> sites;
+            try { sites = EnumerateManagementServers(); }
+            catch (Exception ex) { log.Info($"[FlexViewFed] EnumerateManagementServers failed: {ex.Message}"); sites = new List<SiteRef>(); }
+
+            log.Info($"[FlexViewFed] Management-server sites: {sites.Count}");
+
+            ServerId masterServerId = null;
+            try { masterServerId = EnvironmentManager.Instance.MasterSite?.ServerId; } catch { }
+
+            foreach (var site in sites)
+            {
+                bool isMaster = masterServerId != null && site.ServerId != null &&
+                                site.ServerId.Id == masterServerId.Id;
+                var roots = new List<Item>();
+
+                // The config-plane walk (Configuration.Instance.GetItem(site.Fqid) -> Kind.View) is
+                // the SAME accessor for master and child, because views persist on each site's
+                // management server, not only in the client runtime. Running it on the master too is
+                // the decisive test: if it finds the master's own views (which we KNOW exist), the
+                // approach is proven and child sites should behave identically.
+                var walked = new List<Item>();
+                try
+                {
+                    var siteItem = Configuration.Instance.GetItem(site.Fqid);
+                    if (siteItem == null)
+                        log.Info($"[FlexViewFed] [{site.Name}] GetItem(site) returned null - cannot walk views");
+                    else
+                        CollectViewRoots(siteItem, site.ServerId, walked, site.Name, new HashSet<Guid>(), 0);
+                }
+                catch (Exception ex)
+                {
+                    log.Info($"[FlexViewFed] [{site.Name}] config-walk failed: {ex.Message}");
+                }
+                log.Info($"[FlexViewFed] [{site.Name}] config-walk (GetItem+Kind.View) roots: {walked.Count}");
+
+                if (isMaster)
+                {
+                    // Baseline comparison: the known-good client accessor. If the config-walk count
+                    // matches this, the config-plane path is confirmed equivalent on the master.
+                    int clientCount = -1;
+                    try
+                    {
+                        var groups = ClientControl.Instance.GetViewGroupItems();
+                        clientCount = groups?.Count ?? 0;
+                    }
+                    catch (Exception ex) { log.Info($"[FlexViewFed] [{site.Name}] GetViewGroupItems failed: {ex.Message}"); }
+                    log.Info($"[FlexViewFed] [{site.Name}] (master) ClientControl baseline: {clientCount} group(s) vs config-walk {walked.Count}");
+
+                    // Use whichever accessor actually produced roots so the Open tree still works today:
+                    // prefer the proven config-walk, fall back to ClientControl if it found nothing.
+                    if (walked.Count > 0)
+                        roots.AddRange(walked);
+                    else
+                    {
+                        try
+                        {
+                            var groups = ClientControl.Instance.GetViewGroupItems();
+                            if (groups != null) roots.AddRange(groups);
+                            log.Info($"[FlexViewFed] [{site.Name}] config-walk empty on master - using ClientControl ({roots.Count}).");
+                        }
+                        catch { }
+                    }
+                }
+                else
+                {
+                    roots.AddRange(walked);
+                }
+
+                result.Add(new SiteViews
+                {
+                    Label = (isMaster ? "Master: " : "Site: ") + site.Name,
+                    ViewRoots = roots,
+                    IsMaster = isMaster
+                });
+            }
+
+            return result;
+        }
+
+        // DFS from a site Item collecting the top-most Kind.View items. Descent stops once a Kind.View
+        // item is found on a branch (the browser recurses into it via GetChildren), and never crosses
+        // into a nested child site (a different ServerId) - those are separate site entries. Shallow
+        // levels are logged so we can see exactly what each site exposes.
+        private static void CollectViewRoots(Item node, ServerId siteServerId, List<Item> roots,
+                                             string siteName, HashSet<Guid> seen, int depth)
+        {
+            if (node?.FQID == null || depth > 6) return;
+            if (!seen.Add(node.FQID.ObjectId)) return;
+
+            List<Item> kids = null;
+            try { kids = node.GetChildren(); }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] [{siteName}] GetChildren failed at d{depth} on '{node.Name}': {ex.Message}");
+                return;
+            }
+            if (kids == null) return;
+
+            foreach (var k in kids)
+            {
+                if (k?.FQID == null) continue;
+
+                // A nested child site (different ServerId) is its own entry - do not descend.
+                if (k.FQID.ServerId != null && siteServerId != null && k.FQID.ServerId.Id != siteServerId.Id)
+                    continue;
+
+                if (depth <= 2)
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] [{siteName}] d{depth} child: name='{k.Name}' kind={k.FQID.Kind} folder={k.FQID.FolderType}");
+
+                if (k.FQID.Kind == Kind.View)
+                {
+                    roots.Add(k);   // top-most view item on this branch; browser recurses into it
+                    continue;
+                }
+
+                CollectViewRoots(k, siteServerId, roots, siteName, seen, depth + 1);
+            }
+        }
+
+        // ── Proven federated site-walk (copied from System Status) ─────────────────────────────
+
+        // The raw site walk can surface FQIDs that are not genuine Management Servers (e.g. a
+        // Recording Server's own FQID that appears as a distinct ServerId). Keep only entries whose
+        // Management Server configuration is actually readable - probing RecordingServerFolder throws
+        // for anything that is not a real Management Server. Same filter as System Status.
+        private static List<SiteRef> EnumerateManagementServers()
+        {
+            var log = FlexViewDefinition.Log;
+            var all = EnumerateSites();
+            log.Info($"[FlexViewFed] Sites discovered (raw walk): {all.Count}");
+
+            var result = new List<SiteRef>();
+            foreach (var s in all)
+            {
+                if (s?.Fqid == null) continue;
+                try
+                {
+                    var management = new ManagementServer(s.Fqid);
+                    var _ = management.RecordingServerFolder?.RecordingServers; // throws if not a real MS
+                    result.Add(s);
+                }
+                catch (Exception ex)
+                {
+                    // Not a genuine Management Server (e.g. a Recording Server's own FQID) - excluded.
+                    log.Info($"[FlexViewFed] Excluded non-management-server site '{s.Name}': {ex.GetType().Name}");
+                }
+            }
+            return result;
+        }
+
+        private static List<SiteRef> EnumerateSites()
+        {
+            var list = new List<SiteRef>();
+            var masterFqid = EnvironmentManager.Instance.MasterSite;
+            if (masterFqid == null)
+            {
+                FlexViewDefinition.Log.Info("[FlexViewFed] MasterSite not available - no sites to enumerate");
+                return list;
+            }
+
+            Item masterItem = null;
+            try { masterItem = Configuration.Instance.GetItem(masterFqid); }
+            catch (Exception ex) { FlexViewDefinition.Log.Info($"[FlexViewFed] GetItem(MasterSite) failed: {ex.Message}"); }
+
+            if (masterItem == null)
+            {
+                if (masterFqid.ServerId != null)
+                    list.Add(new SiteRef { Name = masterFqid.ServerId.ServerHostname, Fqid = masterFqid, ServerId = masterFqid.ServerId });
+                return list;
+            }
+
+            CollectSites(masterItem, list, new HashSet<Guid>(), 0);
+            return list;
+        }
+
+        private static void CollectSites(Item site, List<SiteRef> acc, HashSet<Guid> seen, int depth)
+        {
+            var fqid = site?.FQID;
+            if (fqid?.ServerId == null || depth > 8) return;
+            var sid = fqid.ServerId;
+            if (!seen.Add(sid.Id)) return;
+
+            acc.Add(new SiteRef
+            {
+                Name = string.IsNullOrWhiteSpace(site.Name) ? sid.ServerHostname : site.Name,
+                Fqid = fqid,
+                ServerId = sid
+            });
+
+            bool hasKids;
+            try { hasKids = site.HasChildren != HasChildren.No; } catch { hasKids = true; }
+            if (!hasKids) return;
+
+            List<Item> kids = null;
+            try { kids = site.GetChildren(); }
+            catch (Exception ex) { FlexViewDefinition.Log.Info($"[FlexViewFed] GetChildren failed for site '{site.Name}': {ex.Message}"); }
+            if (kids == null) return;
+
+            foreach (var k in kids)
+                CollectSites(k, acc, seen, depth + 1);
+        }
+    }
+}

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -165,6 +165,35 @@ namespace FlexView.Client
                             var preview = xml.Length > 800 ? xml.Substring(0, 800) + " ...[truncated]" : xml;
                             log.Info($"[FlexViewFed] [{siteName}] sample view '{v.Name}' layoutType={fv.LayoutType} LayoutViewItems=\n{preview}");
                         }
+
+                        // LayoutViewItems only carries grid geometry - AddView recreates the panes but not
+                        // camera content (confirmed against a real system: copied views come back with
+                        // correct layout, empty slots). Per-slot content lives separately on
+                        // ViewItemChildItems, one per pane, keyed by ViewItemPosition. Dumping these for
+                        // the first several views (not just the first, which may have no camera panes) so
+                        // the real ViewItemDefinitionXml shape - where the CameraId presumably lives - is
+                        // known before writing code to parse and restore it, rather than guessed at.
+                        if (acc.Count <= 5)
+                        {
+                            try
+                            {
+                                var children = v.ViewItemChildItems;
+                                log.Info($"[FlexViewFed] [{siteName}] view '{v.Name}' ViewItemChildItems count={children?.Count ?? 0}");
+                                if (children != null)
+                                {
+                                    foreach (var vi in children)
+                                    {
+                                        var def = vi?.ViewItemDefinitionXml ?? "";
+                                        var defPreview = def.Length > 500 ? def.Substring(0, 500) + " ...[truncated]" : def;
+                                        log.Info($"[FlexViewFed]   pos={vi?.ViewItemPosition} id={vi?.Id} ViewItemDefinitionXml=\n{defPreview}");
+                                    }
+                                }
+                            }
+                            catch (Exception ex)
+                            {
+                                log.Info($"[FlexViewFed] [{siteName}] ViewItemChildItems read failed for '{v.Name}': {ex.Message}");
+                            }
+                        }
                     }
                 }
             }

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -6,9 +6,8 @@ using VideoOS.Platform.ConfigurationItems;
 
 namespace FlexView.Client
 {
-    // TEST / DIAGNOSTIC (federated views): reads views from the master site and, in a Milestone
-    // Federated Architecture, from its child sites too - straight off each site's Management Server
-    // configuration.
+    // Reads views from the master site and, in a Milestone Federated Architecture, from its child
+    // sites too - straight off each site's Management Server configuration.
     //
     // Views persist on the Management Server (ViewGroupFolder -> ViewGroup -> ViewFolder -> View),
     // exactly like Recording Servers do (RecordingServerFolder -> RecordingServer). So the same
@@ -17,12 +16,20 @@ namespace FlexView.Client
     // configuration-plane read - it does NOT depend on a client session, so it is not subject to the
     // "Cannot work with View Groups in standalone SDK" limitation that ClientControl hits.
     //
+    // A child-site view is never resolved back to a live ViewAndLayoutItem (Configuration.Instance
+    // .GetItem always returns null for it - Views are not part of MFA's federated client-session
+    // model, only devices/cameras/alarms/access are). Instead the raw LayoutViewItems XML and the
+    // handful of other fields ViewFolder.AddView needs are captured here directly from the
+    // configuration-plane View object, so the caller can recreate the view via that same config API
+    // on a site it can write to, without ever needing a client-side handle to the source view.
+    //
     // Everything is logged with the [FlexViewFed] prefix (including a sample view's LayoutViewItems
-    // XML) so a customer test run can be diagnosed - and so we capture the layout format needed to
-    // recreate a child-site view on the parent.
+    // XML) so a customer test run can be diagnosed.
     internal static class FederationWalker
     {
-        // A view read from a site's Management Server configuration.
+        // A view read from a site's Management Server configuration - enough to recreate it
+        // elsewhere via ViewFolder.AddView(name, shortcut, viewLayoutType, layoutCustomId,
+        // layoutIcon, layoutViewItems).
         internal sealed class FedView
         {
             public string SiteName;
@@ -30,10 +37,11 @@ namespace FlexView.Client
             public string Name;
             public string Id;
             public string LayoutType;
+            public string Shortcut;
+            public string LayoutCustomId;
+            public string LayoutIcon;
+            public string LayoutViewItemsXml;
             public bool HasLayoutXml;
-            // Client FQID rebuilt from the view's ServerId + Id, so the view can be resolved back to a
-            // ViewAndLayoutItem via Configuration.Instance.GetItem and opened with the normal pipeline.
-            public FQID Fqid;
         }
 
         internal sealed class SiteViews
@@ -143,8 +151,11 @@ namespace FlexView.Client
                             Name = v.Name,
                             Id = v.Id,
                             LayoutType = SafeGet(() => v.ViewLayoutType),
-                            HasLayoutXml = !string.IsNullOrEmpty(xml),
-                            Fqid = BuildViewFqid(v)
+                            Shortcut = SafeGet(() => v.Shortcut),
+                            LayoutCustomId = SafeGet(() => v.LayoutCustomId),
+                            LayoutIcon = SafeGet(() => v.LayoutIcon),
+                            LayoutViewItemsXml = xml,
+                            HasLayoutXml = !string.IsNullOrEmpty(xml)
                         };
                         acc.Add(fv);
 
@@ -178,24 +189,6 @@ namespace FlexView.Client
         private static string SafeGet(Func<string> f)
         {
             try { return f() ?? ""; } catch { return ""; }
-        }
-
-        // Rebuild a client FQID for a view from its config ServerId + Id, so it can be resolved back
-        // to a ViewAndLayoutItem with Configuration.Instance.GetItem - the same trick used to resolve
-        // a camera FQID elsewhere. Returns null if the id/server is not usable.
-        private static FQID BuildViewFqid(VideoOS.Platform.ConfigurationItems.View v)
-        {
-            try
-            {
-                if (v?.ServerId == null || string.IsNullOrEmpty(v.Id)) return null;
-                if (!Guid.TryParse(v.Id, out var objId)) return null;
-                return new FQID(v.ServerId, Guid.Empty, objId, FolderType.No, Kind.View);
-            }
-            catch (Exception ex)
-            {
-                FlexViewDefinition.Log.Info($"[FlexViewFed] BuildViewFqid failed for '{v?.Name}': {ex.Message}");
-                return null;
-            }
         }
 
         // ── Federated site enumeration (proven pattern from System Status) ─────────────────────

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Xml.Linq;
 using VideoOS.Platform;
 using VideoOS.Platform.Client;
 using VideoOS.Platform.ConfigurationItems;
@@ -42,6 +43,19 @@ namespace FlexView.Client
             public string LayoutIcon;
             public string LayoutViewItemsXml;
             public bool HasLayoutXml;
+
+            // Per-slot content (confirmed against a real system: LayoutViewItems/AddView only carry
+            // grid geometry - camera assignments live separately on ViewItemChildItems, one per pane,
+            // keyed by ViewItemPosition). Only camera slots are captured for now; other view item
+            // types (maps, HTML, plugins) are left as empty panes on copy.
+            public List<FedViewItem> Items = new List<FedViewItem>();
+        }
+
+        // One pane's content, parsed from a ViewItemChildItem's ViewItemDefinitionXml.
+        internal sealed class FedViewItem
+        {
+            public int Position;
+            public Guid? CameraId;
         }
 
         internal sealed class SiteViews
@@ -169,30 +183,32 @@ namespace FlexView.Client
                         // LayoutViewItems only carries grid geometry - AddView recreates the panes but not
                         // camera content (confirmed against a real system: copied views come back with
                         // correct layout, empty slots). Per-slot content lives separately on
-                        // ViewItemChildItems, one per pane, keyed by ViewItemPosition. Dumping these for
-                        // the first several views (not just the first, which may have no camera panes) so
-                        // the real ViewItemDefinitionXml shape - where the CameraId presumably lives - is
-                        // known before writing code to parse and restore it, rather than guessed at.
-                        if (acc.Count <= 5)
+                        // ViewItemChildItems, one per pane, keyed by ViewItemPosition. A camera slot's
+                        // ViewItemDefinitionXml looks like (confirmed from a real dump):
+                        //   <viewitem type="...CameraContentType.CameraViewItem, VideoOS.RemoteClient.Application">
+                        //     <iteminfo cameraid="{guid}" .../>
+                        //   </viewitem>
+                        // Other view item types (maps, HTML, plugins) aren't parsed yet - camera is the
+                        // common case this plugin needs to carry across a federated copy.
+                        try
                         {
-                            try
+                            var children = v.ViewItemChildItems;
+                            if (children != null)
                             {
-                                var children = v.ViewItemChildItems;
-                                log.Info($"[FlexViewFed] [{siteName}] view '{v.Name}' ViewItemChildItems count={children?.Count ?? 0}");
-                                if (children != null)
+                                foreach (var vi in children)
                                 {
-                                    foreach (var vi in children)
-                                    {
-                                        var def = vi?.ViewItemDefinitionXml ?? "";
-                                        var defPreview = def.Length > 500 ? def.Substring(0, 500) + " ...[truncated]" : def;
-                                        log.Info($"[FlexViewFed]   pos={vi?.ViewItemPosition} id={vi?.Id} ViewItemDefinitionXml=\n{defPreview}");
-                                    }
+                                    if (vi == null) continue;
+                                    var camId = ParseCameraId(vi.ViewItemDefinitionXml);
+                                    if (camId != null)
+                                        fv.Items.Add(new FedViewItem { Position = vi.ViewItemPosition, CameraId = camId });
                                 }
                             }
-                            catch (Exception ex)
-                            {
-                                log.Info($"[FlexViewFed] [{siteName}] ViewItemChildItems read failed for '{v.Name}': {ex.Message}");
-                            }
+                            if (acc.Count <= 5)
+                                log.Info($"[FlexViewFed] [{siteName}] view '{v.Name}': {children?.Count ?? 0} view item(s), {fv.Items.Count} camera(s) parsed");
+                        }
+                        catch (Exception ex)
+                        {
+                            log.Info($"[FlexViewFed] [{siteName}] ViewItemChildItems read failed for '{v.Name}': {ex.Message}");
                         }
                     }
                 }
@@ -218,6 +234,26 @@ namespace FlexView.Client
         private static string SafeGet(Func<string> f)
         {
             try { return f() ?? ""; } catch { return ""; }
+        }
+
+        // Extracts the camera GUID from a single view item's definition XML, when it's a camera
+        // slot: <viewitem type="...CameraViewItem..."><iteminfo cameraid="{guid}" ... /></viewitem>.
+        // Returns null for every other view item type (empty, map, HTML, plugin, ...) - those are
+        // left as empty panes on copy rather than guessed at.
+        private static Guid? ParseCameraId(string viewItemDefinitionXml)
+        {
+            if (string.IsNullOrEmpty(viewItemDefinitionXml)) return null;
+            try
+            {
+                var el = XElement.Parse(viewItemDefinitionXml);
+                var type = (string)el.Attribute("type") ?? "";
+                if (type.IndexOf("CameraViewItem", StringComparison.OrdinalIgnoreCase) < 0) return null;
+
+                var camIdStr = (string)el.Element("iteminfo")?.Attribute("cameraid");
+                if (Guid.TryParse(camIdStr, out var camId) && camId != Guid.Empty) return camId;
+            }
+            catch { }
+            return null;
         }
 
         // Finds a ViewGroup config object anywhere under a ViewGroupFolder tree by matching its Id,

--- a/Smart Client Plugins/FlexView/Client/FederationWalker.cs
+++ b/Smart Client Plugins/FlexView/Client/FederationWalker.cs
@@ -191,6 +191,24 @@ namespace FlexView.Client
             try { return f() ?? ""; } catch { return ""; }
         }
 
+        // Finds a ViewGroup config object anywhere under a ViewGroupFolder tree by matching its Id,
+        // walking properties rather than constructing a ViewGroup(FQID) directly from a client Item's
+        // FQID - that constructor validates the FQID came from the same configuration-API object
+        // graph (it throws "Invalid kind for this constructor" otherwise), which a client-session
+        // Item's FQID never satisfies. Every existing working read in this file reaches a ViewGroup
+        // the same way: navigate down from a genuine site FQID via .ViewGroupFolder/.ViewFolder.
+        internal static VideoOS.Platform.ConfigurationItems.ViewGroup FindViewGroupById(ViewGroupFolder folder, Guid id)
+        {
+            if (folder?.ViewGroups == null) return null;
+            foreach (var vg in folder.ViewGroups)
+            {
+                if (Guid.TryParse(vg.Id, out var vgId) && vgId == id) return vg;
+                var found = FindViewGroupById(vg.ViewGroupFolder, id);
+                if (found != null) return found;
+            }
+            return null;
+        }
+
         // ── Federated site enumeration (proven pattern from System Status) ─────────────────────
 
         // Keep only entries whose Management Server configuration is actually readable: the raw walk

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1149,6 +1149,52 @@ namespace FlexView.Client
             public List<FederationWalker.FedViewItem> CameraItems;
         }
 
+        // Resolved once per destination folder, then reused for every view in a batch copy - avoids
+        // re-walking the whole ViewGroupFolder tree (FindViewGroupById) once per selected view, and
+        // ExistingNames lets every view in the batch get a unique name up front instead of each one
+        // finding out about a collision only when AddView itself rejects it.
+        private class DestinationInfo
+        {
+            public VideoOS.Platform.ConfigurationItems.ViewGroup ViewGroup;
+            public ServerId MasterServerId;
+            public HashSet<string> ExistingNames;
+        }
+
+        // Background-thread phase: raw config-API only, no client-session objects touched.
+        private static DestinationInfo ResolveDestination(Item destFolder)
+        {
+            var masterFqid = EnvironmentManager.Instance.MasterSite;
+            if (masterFqid == null) throw new InvalidOperationException("Master site is not available.");
+
+            var ms = new VideoOS.Platform.ConfigurationItems.ManagementServer(masterFqid);
+            var viewGroup = FederationWalker.FindViewGroupById(ms.ViewGroupFolder, destFolder.FQID.ObjectId);
+            if (viewGroup == null)
+                throw new InvalidOperationException($"Could not locate '{destFolder.Name}' in the site configuration.");
+
+            var existingNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            try
+            {
+                var views = viewGroup.ViewFolder?.Views;
+                if (views != null) foreach (var v in views) existingNames.Add(v.Name);
+            }
+            catch { }
+
+            return new DestinationInfo { ViewGroup = viewGroup, MasterServerId = masterFqid.ServerId, ExistingNames = existingNames };
+        }
+
+        // Appends " (n)" until the name doesn't collide with anything already in ExistingNames -
+        // covers both views already in the destination folder and other views earlier in this same
+        // batch (ExistingNames is mutated as each name is claimed).
+        private static string UniqueName(HashSet<string> existingNames, string baseName)
+        {
+            var candidate = baseName;
+            var n = 1;
+            while (existingNames.Contains(candidate))
+                candidate = $"{baseName} ({++n})";
+            existingNames.Add(candidate);
+            return candidate;
+        }
+
         // AddView + WaitForServerTask + reading the source's camera items are all raw config-API
         // calls (VideoOS.Platform.ConfigurationItems) - thread-agnostic, confirmed safe on a
         // background thread. Restoring those cameras onto the new view is NOT: that touches a
@@ -1174,7 +1220,11 @@ namespace FlexView.Client
 
             try
             {
-                var prep = await Task.Run(() => PrepareFederatedCopy(fv, destFolder, newName));
+                var prep = await Task.Run(() =>
+                {
+                    var dest = ResolveDestination(destFolder);
+                    return PrepareFederatedCopy(fv, dest.ViewGroup, dest.MasterServerId, newName);
+                });
 
                 int restored = 0, attempted = prep.CameraItems.Count;
                 if (attempted > 0)
@@ -1195,17 +1245,67 @@ namespace FlexView.Client
             }
         }
 
-        // Background-thread phase: raw config-API only, no client-session objects touched.
-        private static PreparedCopy PrepareFederatedCopy(FederationWalker.FedView fv, Item destFolder, string newName)
+        // Batch version: one destination folder for every selected view (picked once, not per view),
+        // each view keeps its own name - auto-deduped via UniqueName rather than prompted per view -
+        // and one summary dialog covers the whole batch instead of one dialog per view. A failure on
+        // one view is recorded in the summary and does not stop the rest of the batch.
+        private async void CopyMultipleFederatedViewsToLocal(List<FederationWalker.FedView> views)
         {
-            var masterFqid = EnvironmentManager.Instance.MasterSite;
-            if (masterFqid == null) throw new InvalidOperationException("Master site is not available.");
+            if (views == null || views.Count == 0) return;
 
-            var ms = new VideoOS.Platform.ConfigurationItems.ManagementServer(masterFqid);
-            var viewGroup = FederationWalker.FindViewGroupById(ms.ViewGroupFolder, destFolder.FQID.ObjectId);
-            if (viewGroup == null)
-                throw new InvalidOperationException($"Could not locate '{destFolder.Name}' in the site configuration.");
+            var folderPicker = new ViewBrowserWindow(BrowseMode.SelectFolder);
+            folderPicker.Owner = Application.Current.MainWindow;
+            if (folderPicker.ShowDialog() != true || folderPicker.SelectedItem == null) return;
+            var destFolder = folderPicker.SelectedItem;
 
+            DestinationInfo dest;
+            try
+            {
+                dest = await Task.Run(() => ResolveDestination(destFolder));
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] CopyMultipleFederatedViewsToLocal failed to resolve destination: {ex}");
+                MessageDialog.ShowError("Copy Failed", $"Failed to copy views:\n{ex.Message}", Window.GetWindow(this));
+                return;
+            }
+
+            var lines = new List<string>();
+            int succeeded = 0;
+
+            foreach (var fv in views)
+            {
+                var newName = UniqueName(dest.ExistingNames, fv.Name);
+                try
+                {
+                    var prep = await Task.Run(() => PrepareFederatedCopy(fv, dest.ViewGroup, dest.MasterServerId, newName));
+
+                    int restored = 0, attempted = prep.CameraItems.Count;
+                    if (attempted > 0)
+                        restored = await RestoreCameraSlots(prep.MasterServerId, prep.NewViewPath, prep.CameraItems);
+
+                    lines.Add(attempted == 0
+                        ? $"✓ \"{newName}\" (from {fv.SiteName})"
+                        : $"✓ \"{newName}\" (from {fv.SiteName}) - {restored}/{attempted} camera(s)");
+                    succeeded++;
+                }
+                catch (Exception ex)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Batch copy failed for '{fv.Name}' ({fv.SiteName}): {ex}");
+                    lines.Add($"✗ \"{fv.Name}\" (from {fv.SiteName}) - {ex.Message}");
+                }
+            }
+
+            FlexViewDefinition.Log.Info($"[FlexViewFed] Batch copy into '{destFolder.Name}': {succeeded}/{views.Count} view(s) copied.");
+            var title = succeeded == views.Count ? "Views Copied" : "Some Views Failed";
+            MessageDialog.ShowSuccess(title,
+                $"{succeeded} of {views.Count} view(s) copied into \"{destFolder.Name}\":\n\n" + string.Join("\n", lines),
+                Window.GetWindow(this));
+        }
+
+        // Background-thread phase: raw config-API only, no client-session objects touched.
+        private static PreparedCopy PrepareFederatedCopy(FederationWalker.FedView fv, VideoOS.Platform.ConfigurationItems.ViewGroup viewGroup, ServerId masterServerId, string newName)
+        {
             var task = viewGroup.ViewFolder.AddView(
                 newName,
                 fv.Shortcut ?? "",
@@ -1218,7 +1318,7 @@ namespace FlexView.Client
             return new PreparedCopy
             {
                 NewViewPath = task.Path,
-                MasterServerId = masterFqid.ServerId,
+                MasterServerId = masterServerId,
                 CameraItems = FederationWalker.ReadCameraItems(fv)
             };
         }
@@ -1457,6 +1557,13 @@ namespace FlexView.Client
                 var browser = new ViewBrowserWindow(BrowseMode.SelectView, federated: true);
                 browser.Owner = Application.Current.MainWindow;
                 if (browser.ShowDialog() != true) return;
+
+                // Multiple checked child-site views: one folder picker, one batch copy, one summary.
+                if (browser.SelectedFedViews != null && browser.SelectedFedViews.Count > 0)
+                {
+                    CopyMultipleFederatedViewsToLocal(browser.SelectedFedViews);
+                    return;
+                }
 
                 // Child-site view: copy its captured layout XML straight into a folder on this site,
                 // rather than trying to resolve it to a live ViewAndLayoutItem - Views are not part of

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1138,17 +1138,23 @@ namespace FlexView.Client
         // ViewSync's README documents for View Groups). The destination write goes through the same
         // ConfigurationItems API (ViewGroup.ViewFolder.AddView), just targeted at this, locally
         // connected/writable site instead of the source.
-        private class CopyResult
+
+        // Result of the background phase: everything RestoreCameraSlots needs, plus what's needed to
+        // report the outcome. Deliberately carries no ViewAndLayoutItem/client-session object across
+        // the Task.Run boundary - see the thread-affinity note on RestoreCameraSlots below.
+        private class PreparedCopy
         {
-            public int Restored;
-            public int Attempted;
+            public string NewViewPath;
+            public ServerId MasterServerId;
+            public List<FederationWalker.FedViewItem> CameraItems;
         }
 
-        // AddView + WaitForServerTask + the camera-restore retry can together take anywhere from a
-        // few seconds to close to a minute against a real system (confirmed: network round-trips per
-        // poll, not just the sleep between them, add up). All of that used to run directly on the UI
-        // thread and froze Smart Client for the whole duration - it's offloaded to a background
-        // thread here; only the two dialogs (folder/name prompt, and the final result) touch the UI.
+        // AddView + WaitForServerTask + reading the source's camera items are all raw config-API
+        // calls (VideoOS.Platform.ConfigurationItems) - thread-agnostic, confirmed safe on a
+        // background thread. Restoring those cameras onto the new view is NOT: that touches a
+        // ViewAndLayoutItem, a client-session object, on the UI thread only (see RestoreCameraSlots).
+        // So the slow network-bound part runs via Task.Run, and only the final restore step - bounded
+        // to a few seconds by RestoreCameraSlots' own retry cap - runs on the UI thread.
         private async void CopyFederatedViewToLocal(FederationWalker.FedView fv)
         {
             if (fv == null || !fv.HasLayoutXml)
@@ -1168,12 +1174,16 @@ namespace FlexView.Client
 
             try
             {
-                var result = await Task.Run(() => DoCopyFederatedView(fv, destFolder, newName));
+                var prep = await Task.Run(() => PrepareFederatedCopy(fv, destFolder, newName));
 
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{destFolder.Name}' as '{newName}' ({result.Restored}/{result.Attempted} camera(s) restored).");
-                var cameraNote = result.Attempted == 0 ? "" : result.Restored == result.Attempted
-                    ? $" All {result.Attempted} camera(s) were carried over."
-                    : $" {result.Restored} of {result.Attempted} camera(s) were carried over - see MIPLog for the rest.";
+                int restored = 0, attempted = prep.CameraItems.Count;
+                if (attempted > 0)
+                    restored = RestoreCameraSlots(prep.MasterServerId, prep.NewViewPath, prep.CameraItems);
+
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{destFolder.Name}' as '{newName}' ({restored}/{attempted} camera(s) restored).");
+                var cameraNote = attempted == 0 ? "" : restored == attempted
+                    ? $" All {attempted} camera(s) were carried over."
+                    : $" {restored} of {attempted} camera(s) were carried over - see MIPLog for the rest.";
                 MessageDialog.ShowSuccess("View Copied",
                     $"\"{fv.Name}\" was copied from {fv.SiteName} into \"{destFolder.Name}\" as \"{newName}\".{cameraNote}",
                     Window.GetWindow(this));
@@ -1185,8 +1195,8 @@ namespace FlexView.Client
             }
         }
 
-        // The actual copy, run on a background thread - no UI/Dispatcher access in here.
-        private static CopyResult DoCopyFederatedView(FederationWalker.FedView fv, Item destFolder, string newName)
+        // Background-thread phase: raw config-API only, no client-session objects touched.
+        private static PreparedCopy PrepareFederatedCopy(FederationWalker.FedView fv, Item destFolder, string newName)
         {
             var masterFqid = EnvironmentManager.Instance.MasterSite;
             if (masterFqid == null) throw new InvalidOperationException("Master site is not available.");
@@ -1205,11 +1215,12 @@ namespace FlexView.Client
                 fv.LayoutViewItemsXml);
             WaitForServerTask(task, "AddView");
 
-            var cameraItems = FederationWalker.ReadCameraItems(fv);
-            var result = new CopyResult { Attempted = cameraItems.Count };
-            if (result.Attempted > 0)
-                result.Restored = RestoreCameraSlots(masterFqid.ServerId, task.Path, cameraItems);
-            return result;
+            return new PreparedCopy
+            {
+                NewViewPath = task.Path,
+                MasterServerId = masterFqid.ServerId,
+                CameraItems = FederationWalker.ReadCameraItems(fv)
+            };
         }
 
         // Restores camera slots onto the view AddView just created. The destination is always local
@@ -1219,6 +1230,13 @@ namespace FlexView.Client
         // it's the exact same InsertBuiltinViewItem pipeline the same-site copy already uses.
         // Per-slot failures are logged and skipped rather than failing the whole copy - the view and
         // its layout already exist at this point regardless.
+        //
+        // MUST be called on Smart Client's own UI thread. Confirmed against a real run: calling this
+        // from a background thread (it used to be inside the same Task.Run as PrepareFederatedCopy)
+        // throws "The calling thread cannot access this object because a different thread owns it" on
+        // Save - the ViewAndLayoutItem returned by Configuration.Instance.GetItem is a client-session
+        // object with thread affinity, unlike the raw ConfigurationItems.* objects used elsewhere in
+        // this file, which have no such restriction.
         private static int RestoreCameraSlots(ServerId masterServerId, string newViewPath, List<FederationWalker.FedViewItem> items)
         {
             if (string.IsNullOrEmpty(newViewPath)) return 0;

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1170,9 +1170,16 @@ namespace FlexView.Client
                     fv.LayoutViewItemsXml);
                 WaitForServerTask(task, "AddView");
 
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{dlg.SelectedFolder.Name}' as '{dlg.ViewName}'.");
+                int restored = 0, attempted = fv.Items.Count;
+                if (attempted > 0)
+                    restored = RestoreCameraSlots(masterFqid.ServerId, task.Path, fv.Items);
+
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{dlg.SelectedFolder.Name}' as '{dlg.ViewName}' ({restored}/{attempted} camera(s) restored).");
+                var cameraNote = attempted == 0 ? "" : restored == attempted
+                    ? $" All {attempted} camera(s) were carried over."
+                    : $" {restored} of {attempted} camera(s) were carried over - see MIPLog for the rest.";
                 MessageDialog.ShowSuccess("View Copied",
-                    $"\"{fv.Name}\" was copied from {fv.SiteName} into \"{dlg.SelectedFolder.Name}\" as \"{dlg.ViewName}\".",
+                    $"\"{fv.Name}\" was copied from {fv.SiteName} into \"{dlg.SelectedFolder.Name}\" as \"{dlg.ViewName}\".{cameraNote}",
                     Window.GetWindow(this));
             }
             catch (Exception ex)
@@ -1180,6 +1187,67 @@ namespace FlexView.Client
                 FlexViewDefinition.Log.Info($"[FlexViewFed] CopyFederatedViewToLocal failed: {ex}");
                 MessageDialog.ShowError("Copy Failed", $"Failed to copy the view:\n{ex.Message}", Window.GetWindow(this));
             }
+        }
+
+        // Restores camera slots onto the view AddView just created. The destination is always local
+        // (this site), so - unlike the source - Configuration.Instance.GetItem resolves it fine once
+        // we know its Id: ServerTask.Path (from AddView) is the new view's config-API path, used to
+        // read its raw View object and pull out the Id needed to rebuild a client FQID. From there
+        // it's the exact same InsertBuiltinViewItem pipeline the same-site copy already uses.
+        // Per-slot failures are logged and skipped rather than failing the whole copy - the view and
+        // its layout already exist at this point regardless.
+        private static int RestoreCameraSlots(ServerId masterServerId, string newViewPath, List<FederationWalker.FedViewItem> items)
+        {
+            if (string.IsNullOrEmpty(newViewPath)) return 0;
+
+            VideoOS.Platform.ConfigurationItems.View newConfigView;
+            try { newConfigView = new VideoOS.Platform.ConfigurationItems.View(masterServerId, newViewPath); }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Could not read the new view at '{newViewPath}': {ex.Message}");
+                return 0;
+            }
+
+            if (!Guid.TryParse(newConfigView.Id, out var newViewObjectId))
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] New view Id '{newConfigView.Id}' is not a GUID - cannot restore camera content.");
+                return 0;
+            }
+
+            var newViewFqid = new FQID(masterServerId, Guid.Empty, newViewObjectId, FolderType.No, Kind.View);
+            var newClientItem = Configuration.Instance.GetItem(newViewFqid) as ViewAndLayoutItem;
+            if (newClientItem == null)
+            {
+                FlexViewDefinition.Log.Info("[FlexViewFed] Could not resolve the newly created view via the client session - camera content not restored.");
+                return 0;
+            }
+
+            int restored = 0;
+            foreach (var item in items)
+            {
+                if (item.CameraId == null) continue;
+                try
+                {
+                    newClientItem.InsertBuiltinViewItem(item.Position, ViewAndLayoutItem.CameraBuiltinId,
+                        new Dictionary<string, string> { ["CameraId"] = item.CameraId.Value.ToString() });
+                    restored++;
+                }
+                catch (Exception ex)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] slot[{item.Position}]: restore failed for camera {item.CameraId}: {ex.Message}");
+                }
+            }
+
+            if (restored > 0)
+            {
+                try { newClientItem.Save(); }
+                catch (Exception ex)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Save after camera restore failed: {ex.Message}");
+                    return 0;
+                }
+            }
+            return restored;
         }
 
         // AddView/AddViewGroup run as a server-side task that may not be finished when the call

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1153,7 +1153,14 @@ namespace FlexView.Client
 
             try
             {
-                var viewGroup = new VideoOS.Platform.ConfigurationItems.ViewGroup(dlg.SelectedFolder.FQID);
+                var masterFqid = EnvironmentManager.Instance.MasterSite;
+                if (masterFqid == null) throw new InvalidOperationException("Master site is not available.");
+
+                var ms = new VideoOS.Platform.ConfigurationItems.ManagementServer(masterFqid);
+                var viewGroup = FederationWalker.FindViewGroupById(ms.ViewGroupFolder, dlg.SelectedFolder.FQID.ObjectId);
+                if (viewGroup == null)
+                    throw new InvalidOperationException($"Could not locate '{dlg.SelectedFolder.Name}' in the site configuration.");
+
                 var task = viewGroup.ViewFolder.AddView(
                     dlg.ViewName,
                     fv.Shortcut ?? "",

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1110,6 +1110,7 @@ namespace FlexView.Client
             _isEditMode = true;
             _editingView = view;
             _editingParent = parent;
+            _crossSiteSource = null;   // editing a real same-site view, not a cross-site copy
             _selectedPane = null;
             _hoveredPane = null;
 
@@ -1132,6 +1133,45 @@ namespace FlexView.Client
 
             RedrawCanvas();
             UpdateStatus();
+        }
+
+        // TEST (federated views): resolve a child-site view (read from its Management Server config)
+        // back to a client ViewAndLayoutItem via its rebuilt FQID, so the existing open/save pipeline
+        // can consume it. Returns null (logged) if the federated session cannot resolve the item -
+        // that result tells us whether this approach works before we fall back to parsing the raw
+        // LayoutViewItems XML.
+        private ViewAndLayoutItem ResolveFederatedView(FederationWalker.FedView fv)
+        {
+            try
+            {
+                if (fv?.Fqid == null)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve: '{fv?.Name}' has no rebuilt FQID.");
+                    return null;
+                }
+
+                var item = Configuration.Instance.GetItem(fv.Fqid);
+                if (item == null)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve: GetItem returned null for '{fv.Name}' (site '{fv.SiteName}').");
+                    return null;
+                }
+
+                var view = item as ViewAndLayoutItem;
+                if (view == null)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve: item '{item.Name}' is {item.GetType().Name}, not ViewAndLayoutItem.");
+                    return null;
+                }
+
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve OK: '{view.Name}' from site '{fv.SiteName}'.");
+                return view;
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve failed for '{fv?.Name}': {ex.Message}");
+                return null;
+            }
         }
 
         // TEST (federated views): load a view that lives on a child site as an unsaved copy. We never
@@ -1302,21 +1342,37 @@ namespace FlexView.Client
                 // TEST (federated views): browse views across all sites (master + federated children).
                 var browser = new ViewBrowserWindow(BrowseMode.SelectView, federated: true);
                 browser.Owner = Application.Current.MainWindow;
-                if (browser.ShowDialog() == true && browser.SelectedItem != null)
+                if (browser.ShowDialog() != true) return;
+
+                // Child-site view: resolve its rebuilt FQID to a ViewAndLayoutItem, then load as a copy.
+                if (browser.SelectedFedView != null)
                 {
-                    var view = browser.SelectedItem as ViewAndLayoutItem;
-                    if (view == null)
+                    var childView = ResolveFederatedView(browser.SelectedFedView);
+                    if (childView == null)
                     {
-                        FlexViewDefinition.Log.Info($"[FlexViewFed] Selected item '{browser.SelectedItem.Name}' is not a ViewAndLayoutItem (kind={browser.SelectedItem.FQID?.Kind}).");
-                        MessageDialog.ShowError("Open Failed", "Selected item is not a view layout.", Window.GetWindow(this));
+                        MessageDialog.ShowError("Open Failed",
+                            "This view is on another site and could not be resolved through the current session. See MIPLog for details.",
+                            Window.GetWindow(this));
                         return;
                     }
-
-                    if (browser.SelectedIsCrossSite)
-                        LoadCrossSiteViewAsCopy(view);
-                    else
-                        LoadViewForEditing(view, browser.SelectedParent);
+                    LoadCrossSiteViewAsCopy(childView);
+                    return;
                 }
+
+                if (browser.SelectedItem == null) return;
+
+                var view = browser.SelectedItem as ViewAndLayoutItem;
+                if (view == null)
+                {
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Selected item '{browser.SelectedItem.Name}' is not a ViewAndLayoutItem (kind={browser.SelectedItem.FQID?.Kind}).");
+                    MessageDialog.ShowError("Open Failed", "Selected item is not a view layout.", Window.GetWindow(this));
+                    return;
+                }
+
+                if (browser.SelectedIsCrossSite)
+                    LoadCrossSiteViewAsCopy(view);
+                else
+                    LoadViewForEditing(view, browser.SelectedParent);
             }
             catch (Exception ex)
             {
@@ -1359,8 +1415,18 @@ namespace FlexView.Client
             {
                 // TEST (federated views): a copy opened from a child site carries its source name and
                 // slot content (cameras / plugin view items) into the new view saved on the parent.
+                // Reading the source's slot children can fail for a federated item - degrade to a
+                // layout-only save rather than aborting.
                 string defaultName = _crossSiteSource?.Name;
-                List<SlotSnapshot> slotContent = _crossSiteSource != null ? SnapshotSlotContent(_crossSiteSource) : null;
+                List<SlotSnapshot> slotContent = null;
+                if (_crossSiteSource != null)
+                {
+                    try { slotContent = SnapshotSlotContent(_crossSiteSource); }
+                    catch (Exception ex)
+                    {
+                        FlexViewDefinition.Log.Info($"[FlexViewFed] SnapshotSlotContent failed for cross-site source: {ex.Message} - saving layout only.");
+                    }
+                }
 
                 var dlg = new SaveViewWindow(defaultName, _targetFolder);
                 dlg.Owner = Application.Current.MainWindow;

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Shapes;
 using FlexView.Models;
 using VideoOS.Platform;
 using VideoOS.Platform.Client;
+using VideoOS.Platform.ConfigurationItems;
 using SdkRectangle = System.Drawing.Rectangle;
 
 namespace FlexView.Client
@@ -71,11 +72,6 @@ namespace FlexView.Client
 
         // Save target
         private Item _targetFolder;
-
-        // TEST (federated views): when a view is opened from a child site it is loaded as a copy,
-        // never edited in place. This holds the source view so its slot content (camera assignments,
-        // plugin view items) is carried into the new view when saved into a parent folder.
-        private ViewAndLayoutItem _crossSiteSource;
 
         public FlexViewViewItemWpfUserControl()
         {
@@ -1110,7 +1106,6 @@ namespace FlexView.Client
             _isEditMode = true;
             _editingView = view;
             _editingParent = parent;
-            _crossSiteSource = null;   // editing a real same-site view, not a cross-site copy
             _selectedPane = null;
             _hoveredPane = null;
 
@@ -1135,88 +1130,48 @@ namespace FlexView.Client
             UpdateStatus();
         }
 
-        // TEST (federated views): resolve a child-site view (read from its Management Server config)
-        // back to a client ViewAndLayoutItem via its rebuilt FQID, so the existing open/save pipeline
-        // can consume it. Returns null (logged) if the federated session cannot resolve the item -
-        // that result tells us whether this approach works before we fall back to parsing the raw
-        // LayoutViewItems XML.
-        private ViewAndLayoutItem ResolveFederatedView(FederationWalker.FedView fv)
+        // Copies a child-site view straight from its captured Management Server configuration (name,
+        // layout type, and the raw LayoutViewItems XML - the same wire format Get/AddView both read
+        // and write) into a folder on this site. This never routes through Configuration.Instance
+        // .GetItem for the source view - that lookup only resolves items the client session actually
+        // federates, and Views are not part of MFA's federated resource model (same limitation
+        // ViewSync's README documents for View Groups). The destination write goes through the same
+        // ConfigurationItems API (ViewGroup.ViewFolder.AddView), just targeted at this, locally
+        // connected/writable site instead of the source.
+        private void CopyFederatedViewToLocal(FederationWalker.FedView fv)
         {
+            if (fv == null || !fv.HasLayoutXml)
+            {
+                MessageDialog.ShowError("Open Failed",
+                    "This view's layout could not be read from its site's configuration. See MIPLog for details.",
+                    Window.GetWindow(this));
+                return;
+            }
+
+            var dlg = new SaveViewWindow(fv.Name, null);
+            dlg.Owner = Application.Current.MainWindow;
+            if (dlg.ShowDialog() != true) return;
+
             try
             {
-                if (fv?.Fqid == null)
-                {
-                    FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve: '{fv?.Name}' has no rebuilt FQID.");
-                    return null;
-                }
+                var viewGroup = new ViewGroup(dlg.SelectedFolder.FQID);
+                viewGroup.ViewFolder.AddView(
+                    dlg.ViewName,
+                    fv.Shortcut ?? "",
+                    fv.LayoutType ?? "",
+                    fv.LayoutCustomId ?? "",
+                    fv.LayoutIcon ?? "",
+                    fv.LayoutViewItemsXml);
 
-                var item = Configuration.Instance.GetItem(fv.Fqid);
-                if (item == null)
-                {
-                    FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve: GetItem returned null for '{fv.Name}' (site '{fv.SiteName}').");
-                    return null;
-                }
-
-                var view = item as ViewAndLayoutItem;
-                if (view == null)
-                {
-                    FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve: item '{item.Name}' is {item.GetType().Name}, not ViewAndLayoutItem.");
-                    return null;
-                }
-
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve OK: '{view.Name}' from site '{fv.SiteName}'.");
-                return view;
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{dlg.SelectedFolder.Name}' as '{dlg.ViewName}'.");
+                MessageDialog.ShowSuccess("View Copied",
+                    $"\"{fv.Name}\" was copied from {fv.SiteName} into \"{dlg.SelectedFolder.Name}\" as \"{dlg.ViewName}\".",
+                    Window.GetWindow(this));
             }
             catch (Exception ex)
             {
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Resolve failed for '{fv?.Name}': {ex.Message}");
-                return null;
-            }
-        }
-
-        // TEST (federated views): load a view that lives on a child site as an unsaved copy. We never
-        // edit it in place (the child site is read-only through this master session); instead the
-        // panes are loaded fresh so the next Save prompts for a destination folder on the parent
-        // (master). Reading view.Layout / GetChildren here is the crux of the test - if the child
-        // view's layout and slot content come back through the federated session, the copy is
-        // faithful; the results are logged either way.
-        private void LoadCrossSiteViewAsCopy(ViewAndLayoutItem view)
-        {
-            try
-            {
-                var layout = view.Layout;
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Opening cross-site view '{view.Name}': layout slots={(layout?.Length ?? -1)}");
-
-                if (layout == null || layout.Length == 0)
-                {
-                    MessageDialog.ShowError("Open Failed",
-                        "This view is on another site and its layout could not be read through the current session.",
-                        Window.GetWindow(this));
-                    return;
-                }
-
-                LoadFromSdkLayout(layout);
-                TryReadSlotLabels(view);
-
-                // New, unsaved copy: not edit mode, no in-place target. The source is kept so Save
-                // carries its camera / plugin slot content into the new view on the parent.
-                _crossSiteSource = view;
-                _isEditMode = false;
-                _editingView = null;
-                _editingParent = null;
-                _targetFolder = null;
-                _isDirty = true;
-                saveAsButton.Visibility = Visibility.Collapsed;
-                viewNameLabel.Text = view.Name + " (copy from site)";
-
-                RedrawCanvas();
-                UpdateStatus();
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Cross-site view loaded as copy: panes={_panes.Count}. Use Save to store it in a parent folder.");
-            }
-            catch (Exception ex)
-            {
-                FlexViewDefinition.Log.Info($"[FlexViewFed] LoadCrossSiteViewAsCopy failed: {ex}");
-                MessageDialog.ShowError("Open Failed", $"Failed to open the cross-site view:\n{ex.Message}", Window.GetWindow(this));
+                FlexViewDefinition.Log.Info($"[FlexViewFed] CopyFederatedViewToLocal failed: {ex}");
+                MessageDialog.ShowError("Copy Failed", $"Failed to copy the view:\n{ex.Message}", Window.GetWindow(this));
             }
         }
 
@@ -1318,7 +1273,6 @@ namespace FlexView.Client
             _editingView = null;
             _editingParent = null;
             _targetFolder = null;
-            _crossSiteSource = null;
             _isDirty = false;
             saveAsButton.Visibility = Visibility.Collapsed;
             viewNameLabel.Text = "";
@@ -1339,23 +1293,17 @@ namespace FlexView.Client
 
                 if (!proceed) return;
 
-                // TEST (federated views): browse views across all sites (master + federated children).
+                // Browse views across all sites (master + federated children).
                 var browser = new ViewBrowserWindow(BrowseMode.SelectView, federated: true);
                 browser.Owner = Application.Current.MainWindow;
                 if (browser.ShowDialog() != true) return;
 
-                // Child-site view: resolve its rebuilt FQID to a ViewAndLayoutItem, then load as a copy.
+                // Child-site view: copy its captured layout XML straight into a folder on this site,
+                // rather than trying to resolve it to a live ViewAndLayoutItem - Views are not part of
+                // MFA's federated client-session model, so that resolve always returns null.
                 if (browser.SelectedFedView != null)
                 {
-                    var childView = ResolveFederatedView(browser.SelectedFedView);
-                    if (childView == null)
-                    {
-                        MessageDialog.ShowError("Open Failed",
-                            "This view is on another site and could not be resolved through the current session. See MIPLog for details.",
-                            Window.GetWindow(this));
-                        return;
-                    }
-                    LoadCrossSiteViewAsCopy(childView);
+                    CopyFederatedViewToLocal(browser.SelectedFedView);
                     return;
                 }
 
@@ -1369,10 +1317,7 @@ namespace FlexView.Client
                     return;
                 }
 
-                if (browser.SelectedIsCrossSite)
-                    LoadCrossSiteViewAsCopy(view);
-                else
-                    LoadViewForEditing(view, browser.SelectedParent);
+                LoadViewForEditing(view, browser.SelectedParent);
             }
             catch (Exception ex)
             {
@@ -1413,28 +1358,12 @@ namespace FlexView.Client
             }
             else
             {
-                // TEST (federated views): a copy opened from a child site carries its source name and
-                // slot content (cameras / plugin view items) into the new view saved on the parent.
-                // Reading the source's slot children can fail for a federated item - degrade to a
-                // layout-only save rather than aborting.
-                string defaultName = _crossSiteSource?.Name;
-                List<SlotSnapshot> slotContent = null;
-                if (_crossSiteSource != null)
-                {
-                    try { slotContent = SnapshotSlotContent(_crossSiteSource); }
-                    catch (Exception ex)
-                    {
-                        FlexViewDefinition.Log.Info($"[FlexViewFed] SnapshotSlotContent failed for cross-site source: {ex.Message} - saving layout only.");
-                    }
-                }
-
-                var dlg = new SaveViewWindow(defaultName, _targetFolder);
+                var dlg = new SaveViewWindow(null, _targetFolder);
                 dlg.Owner = Application.Current.MainWindow;
                 if (dlg.ShowDialog() == true)
                 {
                     _targetFolder = dlg.SelectedFolder;
-                    var saved = SaveNewView(dlg.ViewName, dlg.SelectedFolder, slotContent);
-                    if (saved != null) _crossSiteSource = null;
+                    SaveNewView(dlg.ViewName, dlg.SelectedFolder);
                 }
             }
         }

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -9,7 +9,6 @@ using System.Windows.Shapes;
 using FlexView.Models;
 using VideoOS.Platform;
 using VideoOS.Platform.Client;
-using VideoOS.Platform.ConfigurationItems;
 using SdkRectangle = System.Drawing.Rectangle;
 
 namespace FlexView.Client
@@ -1154,7 +1153,7 @@ namespace FlexView.Client
 
             try
             {
-                var viewGroup = new ViewGroup(dlg.SelectedFolder.FQID);
+                var viewGroup = new VideoOS.Platform.ConfigurationItems.ViewGroup(dlg.SelectedFolder.FQID);
                 var task = viewGroup.ViewFolder.AddView(
                     dlg.ViewName,
                     fv.Shortcut ?? "",

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1155,13 +1155,14 @@ namespace FlexView.Client
             try
             {
                 var viewGroup = new ViewGroup(dlg.SelectedFolder.FQID);
-                viewGroup.ViewFolder.AddView(
+                var task = viewGroup.ViewFolder.AddView(
                     dlg.ViewName,
                     fv.Shortcut ?? "",
                     fv.LayoutType ?? "",
                     fv.LayoutCustomId ?? "",
                     fv.LayoutIcon ?? "",
                     fv.LayoutViewItemsXml);
+                WaitForServerTask(task, "AddView");
 
                 FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{dlg.SelectedFolder.Name}' as '{dlg.ViewName}'.");
                 MessageDialog.ShowSuccess("View Copied",
@@ -1173,6 +1174,25 @@ namespace FlexView.Client
                 FlexViewDefinition.Log.Info($"[FlexViewFed] CopyFederatedViewToLocal failed: {ex}");
                 MessageDialog.ShowError("Copy Failed", $"Failed to copy the view:\n{ex.Message}", Window.GetWindow(this));
             }
+        }
+
+        // AddView/AddViewGroup run as a server-side task that may not be finished when the call
+        // returns (ServerTask.Progress < 100) - the SDK docs say to poll UpdateState() until it
+        // completes. Without this, a server-side failure (e.g. a duplicate name) would otherwise be
+        // reported back as a success.
+        private static void WaitForServerTask(VideoOS.Platform.ConfigurationItems.ServerTask task, string what)
+        {
+            if (task == null) throw new InvalidOperationException($"{what}: server returned no task.");
+
+            var deadline = DateTime.UtcNow.AddSeconds(15);
+            while (task.Progress < 100 && task.State != VideoOS.Platform.ConfigurationItems.StateEnum.Error && DateTime.UtcNow < deadline)
+            {
+                System.Threading.Thread.Sleep(200);
+                task.UpdateState();
+            }
+
+            if (task.State == VideoOS.Platform.ConfigurationItems.StateEnum.Error)
+                throw new InvalidOperationException($"{what} failed: {task.ErrorText ?? task.ErrorCode ?? "unknown error"}");
         }
 
         private void TryReadSlotLabels(ViewAndLayoutItem view)

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -72,6 +72,11 @@ namespace FlexView.Client
         // Save target
         private Item _targetFolder;
 
+        // TEST (federated views): when a view is opened from a child site it is loaded as a copy,
+        // never edited in place. This holds the source view so its slot content (camera assignments,
+        // plugin view items) is carried into the new view when saved into a parent folder.
+        private ViewAndLayoutItem _crossSiteSource;
+
         public FlexViewViewItemWpfUserControl()
         {
             InitializeComponent();
@@ -1129,6 +1134,52 @@ namespace FlexView.Client
             UpdateStatus();
         }
 
+        // TEST (federated views): load a view that lives on a child site as an unsaved copy. We never
+        // edit it in place (the child site is read-only through this master session); instead the
+        // panes are loaded fresh so the next Save prompts for a destination folder on the parent
+        // (master). Reading view.Layout / GetChildren here is the crux of the test - if the child
+        // view's layout and slot content come back through the federated session, the copy is
+        // faithful; the results are logged either way.
+        private void LoadCrossSiteViewAsCopy(ViewAndLayoutItem view)
+        {
+            try
+            {
+                var layout = view.Layout;
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Opening cross-site view '{view.Name}': layout slots={(layout?.Length ?? -1)}");
+
+                if (layout == null || layout.Length == 0)
+                {
+                    MessageDialog.ShowError("Open Failed",
+                        "This view is on another site and its layout could not be read through the current session.",
+                        Window.GetWindow(this));
+                    return;
+                }
+
+                LoadFromSdkLayout(layout);
+                TryReadSlotLabels(view);
+
+                // New, unsaved copy: not edit mode, no in-place target. The source is kept so Save
+                // carries its camera / plugin slot content into the new view on the parent.
+                _crossSiteSource = view;
+                _isEditMode = false;
+                _editingView = null;
+                _editingParent = null;
+                _targetFolder = null;
+                _isDirty = true;
+                saveAsButton.Visibility = Visibility.Collapsed;
+                viewNameLabel.Text = view.Name + " (copy from site)";
+
+                RedrawCanvas();
+                UpdateStatus();
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Cross-site view loaded as copy: panes={_panes.Count}. Use Save to store it in a parent folder.");
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] LoadCrossSiteViewAsCopy failed: {ex}");
+                MessageDialog.ShowError("Open Failed", $"Failed to open the cross-site view:\n{ex.Message}", Window.GetWindow(this));
+            }
+        }
+
         private void TryReadSlotLabels(ViewAndLayoutItem view)
         {
             try
@@ -1227,6 +1278,7 @@ namespace FlexView.Client
             _editingView = null;
             _editingParent = null;
             _targetFolder = null;
+            _crossSiteSource = null;
             _isDirty = false;
             saveAsButton.Visibility = Visibility.Collapsed;
             viewNameLabel.Text = "";
@@ -1247,18 +1299,23 @@ namespace FlexView.Client
 
                 if (!proceed) return;
 
-                var browser = new ViewBrowserWindow(BrowseMode.SelectView);
+                // TEST (federated views): browse views across all sites (master + federated children).
+                var browser = new ViewBrowserWindow(BrowseMode.SelectView, federated: true);
                 browser.Owner = Application.Current.MainWindow;
                 if (browser.ShowDialog() == true && browser.SelectedItem != null)
                 {
                     var view = browser.SelectedItem as ViewAndLayoutItem;
                     if (view == null)
                     {
+                        FlexViewDefinition.Log.Info($"[FlexViewFed] Selected item '{browser.SelectedItem.Name}' is not a ViewAndLayoutItem (kind={browser.SelectedItem.FQID?.Kind}).");
                         MessageDialog.ShowError("Open Failed", "Selected item is not a view layout.", Window.GetWindow(this));
                         return;
                     }
 
-                    LoadViewForEditing(view, browser.SelectedParent);
+                    if (browser.SelectedIsCrossSite)
+                        LoadCrossSiteViewAsCopy(view);
+                    else
+                        LoadViewForEditing(view, browser.SelectedParent);
                 }
             }
             catch (Exception ex)
@@ -1300,12 +1357,18 @@ namespace FlexView.Client
             }
             else
             {
-                var dlg = new SaveViewWindow(null, _targetFolder);
+                // TEST (federated views): a copy opened from a child site carries its source name and
+                // slot content (cameras / plugin view items) into the new view saved on the parent.
+                string defaultName = _crossSiteSource?.Name;
+                List<SlotSnapshot> slotContent = _crossSiteSource != null ? SnapshotSlotContent(_crossSiteSource) : null;
+
+                var dlg = new SaveViewWindow(defaultName, _targetFolder);
                 dlg.Owner = Application.Current.MainWindow;
                 if (dlg.ShowDialog() == true)
                 {
                     _targetFolder = dlg.SelectedFolder;
-                    SaveNewView(dlg.ViewName, dlg.SelectedFolder);
+                    var saved = SaveNewView(dlg.ViewName, dlg.SelectedFolder, slotContent);
+                    if (saved != null) _crossSiteSource = null;
                 }
             }
         }

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1214,11 +1214,22 @@ namespace FlexView.Client
                 return 0;
             }
 
+            // The client session's own item cache for built-in kinds (View included) doesn't see a
+            // just-created item immediately - it was written through the raw config API, a side
+            // channel the client cache isn't notified about synchronously. Configuration.RefreshConfiguration
+            // explicitly does not apply here (SDK docs: "Only works for plug-in defined configurations
+            // ... built-in item types ... cannot be refreshed"), so the only option is to wait the
+            // environment's own propagation out with a bounded retry.
             var newViewFqid = new FQID(masterServerId, Guid.Empty, newViewObjectId, FolderType.No, Kind.View);
-            var newClientItem = Configuration.Instance.GetItem(newViewFqid) as ViewAndLayoutItem;
+            ViewAndLayoutItem newClientItem = null;
+            for (int attempt = 1; attempt <= 15 && newClientItem == null; attempt++)
+            {
+                if (attempt > 1) System.Threading.Thread.Sleep(500);
+                newClientItem = Configuration.Instance.GetItem(newViewFqid) as ViewAndLayoutItem;
+            }
             if (newClientItem == null)
             {
-                FlexViewDefinition.Log.Info("[FlexViewFed] Could not resolve the newly created view via the client session - camera content not restored.");
+                FlexViewDefinition.Log.Info("[FlexViewFed] Could not resolve the newly created view via the client session after retrying - camera content not restored.");
                 return 0;
             }
 

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Shapes;
+using System.Threading.Tasks;
 using FlexView.Models;
 using VideoOS.Platform;
 using VideoOS.Platform.Client;
@@ -1137,7 +1138,18 @@ namespace FlexView.Client
         // ViewSync's README documents for View Groups). The destination write goes through the same
         // ConfigurationItems API (ViewGroup.ViewFolder.AddView), just targeted at this, locally
         // connected/writable site instead of the source.
-        private void CopyFederatedViewToLocal(FederationWalker.FedView fv)
+        private class CopyResult
+        {
+            public int Restored;
+            public int Attempted;
+        }
+
+        // AddView + WaitForServerTask + the camera-restore retry can together take anywhere from a
+        // few seconds to close to a minute against a real system (confirmed: network round-trips per
+        // poll, not just the sleep between them, add up). All of that used to run directly on the UI
+        // thread and froze Smart Client for the whole duration - it's offloaded to a background
+        // thread here; only the two dialogs (folder/name prompt, and the final result) touch the UI.
+        private async void CopyFederatedViewToLocal(FederationWalker.FedView fv)
         {
             if (fv == null || !fv.HasLayoutXml)
             {
@@ -1151,35 +1163,19 @@ namespace FlexView.Client
             dlg.Owner = Application.Current.MainWindow;
             if (dlg.ShowDialog() != true) return;
 
+            var destFolder = dlg.SelectedFolder;
+            var newName = dlg.ViewName;
+
             try
             {
-                var masterFqid = EnvironmentManager.Instance.MasterSite;
-                if (masterFqid == null) throw new InvalidOperationException("Master site is not available.");
+                var result = await Task.Run(() => DoCopyFederatedView(fv, destFolder, newName));
 
-                var ms = new VideoOS.Platform.ConfigurationItems.ManagementServer(masterFqid);
-                var viewGroup = FederationWalker.FindViewGroupById(ms.ViewGroupFolder, dlg.SelectedFolder.FQID.ObjectId);
-                if (viewGroup == null)
-                    throw new InvalidOperationException($"Could not locate '{dlg.SelectedFolder.Name}' in the site configuration.");
-
-                var task = viewGroup.ViewFolder.AddView(
-                    dlg.ViewName,
-                    fv.Shortcut ?? "",
-                    fv.LayoutType ?? "",
-                    fv.LayoutCustomId ?? "",
-                    fv.LayoutIcon ?? "",
-                    fv.LayoutViewItemsXml);
-                WaitForServerTask(task, "AddView");
-
-                int restored = 0, attempted = fv.Items.Count;
-                if (attempted > 0)
-                    restored = RestoreCameraSlots(masterFqid.ServerId, task.Path, fv.Items);
-
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{dlg.SelectedFolder.Name}' as '{dlg.ViewName}' ({restored}/{attempted} camera(s) restored).");
-                var cameraNote = attempted == 0 ? "" : restored == attempted
-                    ? $" All {attempted} camera(s) were carried over."
-                    : $" {restored} of {attempted} camera(s) were carried over - see MIPLog for the rest.";
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{destFolder.Name}' as '{newName}' ({result.Restored}/{result.Attempted} camera(s) restored).");
+                var cameraNote = result.Attempted == 0 ? "" : result.Restored == result.Attempted
+                    ? $" All {result.Attempted} camera(s) were carried over."
+                    : $" {result.Restored} of {result.Attempted} camera(s) were carried over - see MIPLog for the rest.";
                 MessageDialog.ShowSuccess("View Copied",
-                    $"\"{fv.Name}\" was copied from {fv.SiteName} into \"{dlg.SelectedFolder.Name}\" as \"{dlg.ViewName}\".{cameraNote}",
+                    $"\"{fv.Name}\" was copied from {fv.SiteName} into \"{destFolder.Name}\" as \"{newName}\".{cameraNote}",
                     Window.GetWindow(this));
             }
             catch (Exception ex)
@@ -1187,6 +1183,33 @@ namespace FlexView.Client
                 FlexViewDefinition.Log.Info($"[FlexViewFed] CopyFederatedViewToLocal failed: {ex}");
                 MessageDialog.ShowError("Copy Failed", $"Failed to copy the view:\n{ex.Message}", Window.GetWindow(this));
             }
+        }
+
+        // The actual copy, run on a background thread - no UI/Dispatcher access in here.
+        private static CopyResult DoCopyFederatedView(FederationWalker.FedView fv, Item destFolder, string newName)
+        {
+            var masterFqid = EnvironmentManager.Instance.MasterSite;
+            if (masterFqid == null) throw new InvalidOperationException("Master site is not available.");
+
+            var ms = new VideoOS.Platform.ConfigurationItems.ManagementServer(masterFqid);
+            var viewGroup = FederationWalker.FindViewGroupById(ms.ViewGroupFolder, destFolder.FQID.ObjectId);
+            if (viewGroup == null)
+                throw new InvalidOperationException($"Could not locate '{destFolder.Name}' in the site configuration.");
+
+            var task = viewGroup.ViewFolder.AddView(
+                newName,
+                fv.Shortcut ?? "",
+                fv.LayoutType ?? "",
+                fv.LayoutCustomId ?? "",
+                fv.LayoutIcon ?? "",
+                fv.LayoutViewItemsXml);
+            WaitForServerTask(task, "AddView");
+
+            var cameraItems = FederationWalker.ReadCameraItems(fv);
+            var result = new CopyResult { Attempted = cameraItems.Count };
+            if (result.Attempted > 0)
+                result.Restored = RestoreCameraSlots(masterFqid.ServerId, task.Path, cameraItems);
+            return result;
         }
 
         // Restores camera slots onto the view AddView just created. The destination is always local

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1178,7 +1178,7 @@ namespace FlexView.Client
 
                 int restored = 0, attempted = prep.CameraItems.Count;
                 if (attempted > 0)
-                    restored = RestoreCameraSlots(prep.MasterServerId, prep.NewViewPath, prep.CameraItems);
+                    restored = await RestoreCameraSlots(prep.MasterServerId, prep.NewViewPath, prep.CameraItems);
 
                 FlexViewDefinition.Log.Info($"[FlexViewFed] Copied '{fv.Name}' from site '{fv.SiteName}' into '{destFolder.Name}' as '{newName}' ({restored}/{attempted} camera(s) restored).");
                 var cameraNote = attempted == 0 ? "" : restored == attempted
@@ -1232,12 +1232,19 @@ namespace FlexView.Client
         // its layout already exist at this point regardless.
         //
         // MUST be called on Smart Client's own UI thread. Confirmed against a real run: calling this
-        // from a background thread (it used to be inside the same Task.Run as PrepareFederatedCopy)
-        // throws "The calling thread cannot access this object because a different thread owns it" on
-        // Save - the ViewAndLayoutItem returned by Configuration.Instance.GetItem is a client-session
-        // object with thread affinity, unlike the raw ConfigurationItems.* objects used elsewhere in
-        // this file, which have no such restriction.
-        private static int RestoreCameraSlots(ServerId masterServerId, string newViewPath, List<FederationWalker.FedViewItem> items)
+        // from a background thread throws "The calling thread cannot access this object because a
+        // different thread owns it" on Save - the ViewAndLayoutItem returned by Configuration.Instance
+        // .GetItem is a client-session object with thread affinity, unlike the raw ConfigurationItems.*
+        // objects used elsewhere in this file, which have no such restriction.
+        //
+        // Uses await Task.Delay (not Thread.Sleep) between retry attempts so the UI stays responsive
+        // while waiting - confirmed against a real system that the client cache can take 45+ seconds
+        // to notice a view created through the raw config API side channel, and each GetItem attempt
+        // itself (not just the delay between attempts) can take 2-3 seconds since it's a real network
+        // call that must run on this thread. Delay-based yielding can't eliminate that per-attempt
+        // cost, but it does mean Smart Client's message pump isn't dead for the whole wait - just
+        // briefly busy during each individual attempt.
+        private static async Task<int> RestoreCameraSlots(ServerId masterServerId, string newViewPath, List<FederationWalker.FedViewItem> items)
         {
             if (string.IsNullOrEmpty(newViewPath)) return 0;
 
@@ -1263,14 +1270,17 @@ namespace FlexView.Client
             // environment's own propagation out with a bounded retry.
             var newViewFqid = new FQID(masterServerId, Guid.Empty, newViewObjectId, FolderType.No, Kind.View);
             ViewAndLayoutItem newClientItem = null;
-            for (int attempt = 1; attempt <= 15 && newClientItem == null; attempt++)
+            var deadline = DateTime.UtcNow.AddSeconds(90);
+            int attempt = 0;
+            while (newClientItem == null && DateTime.UtcNow < deadline)
             {
-                if (attempt > 1) System.Threading.Thread.Sleep(500);
+                attempt++;
+                if (attempt > 1) await Task.Delay(500);
                 newClientItem = Configuration.Instance.GetItem(newViewFqid) as ViewAndLayoutItem;
             }
             if (newClientItem == null)
             {
-                FlexViewDefinition.Log.Info("[FlexViewFed] Could not resolve the newly created view via the client session after retrying - camera content not restored.");
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Could not resolve the newly created view via the client session after {attempt} attempt(s) - camera content not restored.");
                 return 0;
             }
 
@@ -1290,13 +1300,17 @@ namespace FlexView.Client
                 }
             }
 
+            // Confirmed against a real run: InsertBuiltinViewItem's changes stuck (the resulting view
+            // genuinely had working cameras) even on a run where this Save() call itself failed (it was
+            // called from the wrong thread, before this method was fixed to always run on the UI
+            // thread). So a Save() failure here is logged but does not roll the already-successful
+            // restored count back to 0 - that undercounted a copy that had actually worked.
             if (restored > 0)
             {
                 try { newClientItem.Save(); }
                 catch (Exception ex)
                 {
-                    FlexViewDefinition.Log.Info($"[FlexViewFed] Save after camera restore failed: {ex.Message}");
-                    return 0;
+                    FlexViewDefinition.Log.Info($"[FlexViewFed] Save after camera restore failed (restored slots may already be persisted regardless): {ex.Message}");
                 }
             }
             return restored;

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml
@@ -76,8 +76,15 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <TextBlock x:Name="headerText" Grid.Row="0" Text="Select a folder"
-                   Foreground="White" FontSize="14" FontWeight="SemiBold" Margin="0,0,0,10"/>
+        <DockPanel Grid.Row="0" Margin="0,0,0,10">
+            <Button x:Name="refreshButton" DockPanel.Dock="Right" Content="Refresh" Visibility="Collapsed"
+                    Style="{StaticResource FlatButton}"
+                    Click="OnRefreshClick" Padding="10,4"
+                    MinHeight="26" MinWidth="70" FontSize="11"
+                    ToolTip="Re-walk every site's views - use if a view was added, moved, or renamed on another site since this list was last loaded"/>
+            <TextBlock x:Name="headerText" Text="Select a folder"
+                       Foreground="White" FontSize="14" FontWeight="SemiBold" VerticalAlignment="Center"/>
+        </DockPanel>
 
         <TextBox x:Name="searchBox" Grid.Row="1" Margin="0,0,0,8"
                  Background="#FF050811" Foreground="#FFE6EDF3" CaretBrush="White"

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -25,6 +25,10 @@ namespace FlexView.Client
         // a parent (master) folder rather than written back to the child site.
         public bool SelectedIsCrossSite { get; private set; }
 
+        // TEST (federated views): set when the selection is a child-site view read from the
+        // Management Server config (rather than a master client Item). Carries the rebuilt FQID.
+        internal FederationWalker.FedView SelectedFedView { get; private set; }
+
         public ViewBrowserWindow(BrowseMode mode) : this(mode, false) { }
 
         public ViewBrowserWindow(BrowseMode mode, bool federated)
@@ -93,6 +97,8 @@ namespace FlexView.Client
                 return;
             }
 
+            var dim = new SolidColorBrush(Color.FromRgb(0x8B, 0x94, 0x9E));
+
             foreach (var sv in siteViews)
             {
                 var header = new TreeViewItem
@@ -104,12 +110,34 @@ namespace FlexView.Client
                 };
 
                 int added = 0;
-                if (sv.ViewRoots != null)
+
+                if (sv.IsMaster)
                 {
-                    foreach (var root in sv.ViewRoots)
+                    // Master: real client Items - fully selectable/openable, same as today.
+                    foreach (var root in sv.ClientViewRoots)
                     {
                         var node = CreateTreeNode(root);
                         if (node != null) { header.Items.Add(node); added++; }
+                    }
+                }
+                else
+                {
+                    // Child site: views read from the Management Server config. Each carries a rebuilt
+                    // FQID so it can be resolved to a ViewAndLayoutItem and opened as a copy, then
+                    // saved into a parent folder. Views whose FQID could not be rebuilt are shown but
+                    // not selectable.
+                    foreach (var fv in sv.FedViews)
+                    {
+                        bool openable = fv.Fqid != null;
+                        header.Items.Add(new TreeViewItem
+                        {
+                            Header = $"\U0001F4CB {fv.GroupPath} / {fv.Name}" + (openable ? "" : "   [not resolvable]"),
+                            Foreground = openable ? Brushes.White : dim,
+                            Tag = openable ? fv : null,     // FedView tag = selectable child view
+                            FontWeight = FontWeights.Normal,
+                            IsExpanded = false
+                        });
+                        added++;
                     }
                 }
 
@@ -118,7 +146,7 @@ namespace FlexView.Client
                     header.Items.Add(new TreeViewItem
                     {
                         Header = "   (no views reachable)",
-                        Foreground = new SolidColorBrush(Color.FromRgb(0x8B, 0x94, 0x9E)),
+                        Foreground = dim,
                         Tag = null,
                         FontWeight = FontWeights.Normal
                     });
@@ -174,6 +202,14 @@ namespace FlexView.Client
                 return;
             }
 
+            // Federated child-site view (read from the Management Server config): selectable only
+            // when opening a view, never as a save folder.
+            if (selected.Tag is FederationWalker.FedView)
+            {
+                btnSelect.IsEnabled = _mode == BrowseMode.SelectView;
+                return;
+            }
+
             var item = selected.Tag as Item;
             if (item == null)
             {
@@ -223,8 +259,12 @@ namespace FlexView.Client
         private static bool NodeMatches(TreeViewItem node, string query)
         {
             var item = node.Tag as Item;
-            if (item == null) return false;
-            return (item.Name ?? string.Empty).IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
+            if (item != null)
+                return (item.Name ?? string.Empty).IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
+
+            // Federated site-header / read-only child-view nodes carry no Item tag; match their text.
+            var header = node.Header as string;
+            return header != null && header.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private void OnSelectClick(object sender, RoutedEventArgs e)
@@ -232,7 +272,20 @@ namespace FlexView.Client
             var selected = tree.SelectedItem as TreeViewItem;
             if (selected == null) return;
 
+            // TEST (federated views): a child-site view carries a FedView tag, not a client Item.
+            if (selected.Tag is FederationWalker.FedView fv)
+            {
+                SelectedFedView = fv;
+                SelectedItem = null;
+                SelectedParent = null;
+                SelectedIsCrossSite = true;
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Selected child-site view '{fv.Name}' on '{fv.SiteName}' (fqid={(fv.Fqid != null)})");
+                DialogResult = true;
+                return;
+            }
+
             SelectedItem = selected.Tag as Item;
+            SelectedFedView = null;
 
             var parentNode = selected.Parent as TreeViewItem;
             if (parentNode != null)

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -24,6 +25,13 @@ namespace FlexView.Client
         // Set when the selection is a child-site view read from the Management Server config
         // (rather than a master client Item). Carries its captured layout XML for copying.
         internal FederationWalker.FedView SelectedFedView { get; private set; }
+
+        // Set instead of SelectedFedView when one or more checkboxes are checked - batch copy mode.
+        // Takes priority over SelectedFedView/SelectedItem when populated.
+        internal List<FederationWalker.FedView> SelectedFedViews { get; private set; }
+
+        // Tracks which federated views are checked, across every site's subtree in the tree at once.
+        private readonly HashSet<FederationWalker.FedView> _checkedFedViews = new HashSet<FederationWalker.FedView>();
 
         public ViewBrowserWindow(BrowseMode mode) : this(mode, false) { }
 
@@ -158,13 +166,39 @@ namespace FlexView.Client
                     // Child site: views read from the Management Server config, each carrying its own
                     // captured layout XML so it can be copied into a folder on this site without ever
                     // needing a client-side handle to the source view. Views whose layout XML could
-                    // not be read are shown but not selectable.
+                    // not be read are shown but not selectable. Openable ones get a checkbox so several
+                    // can be picked at once for a batch copy, in addition to the existing single-click
+                    // Select flow.
                     foreach (var fv in sv.FedViews)
                     {
                         bool openable = fv.HasLayoutXml;
+                        var label = $"{fv.GroupPath} / {fv.Name}" + (openable ? "" : "   [not resolvable]");
+
+                        object headerContent;
+                        if (openable)
+                        {
+                            var panel = new StackPanel { Orientation = Orientation.Horizontal };
+                            var checkBox = new CheckBox
+                            {
+                                Tag = fv,
+                                VerticalAlignment = VerticalAlignment.Center,
+                                Margin = new Thickness(0, 0, 6, 0),
+                                IsChecked = _checkedFedViews.Contains(fv)
+                            };
+                            checkBox.Checked += OnFedViewCheckChanged;
+                            checkBox.Unchecked += OnFedViewCheckChanged;
+                            panel.Children.Add(checkBox);
+                            panel.Children.Add(new TextBlock { Text = "\U0001F4CB " + label, Foreground = Brushes.White, VerticalAlignment = VerticalAlignment.Center });
+                            headerContent = panel;
+                        }
+                        else
+                        {
+                            headerContent = "\U0001F4CB " + label;
+                        }
+
                         header.Items.Add(new TreeViewItem
                         {
-                            Header = $"\U0001F4CB {fv.GroupPath} / {fv.Name}" + (openable ? "" : "   [not resolvable]"),
+                            Header = headerContent,
                             Foreground = openable ? Brushes.White : dim,
                             Tag = openable ? fv : null,     // FedView tag = selectable child view
                             FontWeight = FontWeights.Normal,
@@ -257,6 +291,15 @@ namespace FlexView.Client
 
         private void Tree_SelectedItemChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
         {
+            // While any checkboxes are checked, the button is in batch-copy mode and its enabled
+            // state/label are driven by the checked count, not by whatever row happens to be
+            // highlighted - see OnFedViewCheckChanged.
+            if (_checkedFedViews.Count > 0) return;
+            RefreshSelectButtonForSingleSelection();
+        }
+
+        private void RefreshSelectButtonForSingleSelection()
+        {
             var selected = tree.SelectedItem as TreeViewItem;
             if (selected == null)
             {
@@ -285,6 +328,29 @@ namespace FlexView.Client
                 btnSelect.IsEnabled = isFolder;
             else
                 btnSelect.IsEnabled = !isFolder;
+        }
+
+        // A checkbox next to an openable federated view was toggled. While one or more are checked,
+        // btnSelect switches to "Copy N Selected" and closing the dialog returns SelectedFedViews
+        // instead of the single-selection properties - see OnSelectClick.
+        private void OnFedViewCheckChanged(object sender, RoutedEventArgs e)
+        {
+            var checkBox = sender as CheckBox;
+            if (!(checkBox?.Tag is FederationWalker.FedView fv)) return;
+
+            if (checkBox.IsChecked == true) _checkedFedViews.Add(fv);
+            else _checkedFedViews.Remove(fv);
+
+            if (_checkedFedViews.Count > 0)
+            {
+                btnSelect.Content = $"Copy {_checkedFedViews.Count} Selected";
+                btnSelect.IsEnabled = true;
+            }
+            else
+            {
+                btnSelect.Content = "Select";
+                RefreshSelectButtonForSingleSelection();
+            }
         }
 
         private void OnSearchTextChanged(object sender, TextChangedEventArgs e)
@@ -324,13 +390,34 @@ namespace FlexView.Client
             if (item != null)
                 return (item.Name ?? string.Empty).IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
 
-            // Federated site-header / read-only child-view nodes carry no Item tag; match their text.
+            // Openable federated views carry a FedView tag - their Header is a StackPanel (checkbox +
+            // text), not a plain string, since the checkbox was added for batch selection.
+            if (node.Tag is FederationWalker.FedView fv)
+            {
+                var text = $"{fv.GroupPath} / {fv.Name}";
+                return text.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
+            }
+
+            // Site headers / non-resolvable child views carry no Tag at all; match their plain-string text.
             var header = node.Header as string;
             return header != null && header.IndexOf(query, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         private void OnSelectClick(object sender, RoutedEventArgs e)
         {
+            // Batch mode: one or more checkboxes are checked - return all of them regardless of
+            // whatever row is currently highlighted in the tree.
+            if (_checkedFedViews.Count > 0)
+            {
+                SelectedFedViews = _checkedFedViews.ToList();
+                SelectedFedView = null;
+                SelectedItem = null;
+                SelectedParent = null;
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Selected {SelectedFedViews.Count} child-site view(s) for batch copy.");
+                DialogResult = true;
+                return;
+            }
+
             var selected = tree.SelectedItem as TreeViewItem;
             if (selected == null) return;
 

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -36,7 +36,18 @@ namespace FlexView.Client
                 ? "Select a folder to save the view in"
                 : "Select a view to edit";
             searchBox.ToolTip = "Type to filter by name";
+            refreshButton.Visibility = (_federated && _mode == BrowseMode.SelectView) ? Visibility.Visible : Visibility.Collapsed;
             LoadTree();
+        }
+
+        // The federated site/view list is cached for the session (see FederationWalker) - re-walking
+        // every site on every Open View click was the original ~90-second-per-open complaint. Refresh
+        // is the manual escape hatch for the rare case something changed on another site since.
+        private void OnRefreshClick(object sender, RoutedEventArgs e)
+        {
+            FederationWalker.ForceRefresh();
+            tree.Items.Clear();
+            LoadTreeFederatedAsync();
         }
 
         private void LoadTree()
@@ -88,6 +99,7 @@ namespace FlexView.Client
             };
             tree.Items.Add(loadingNode);
             searchBox.IsEnabled = false;
+            refreshButton.IsEnabled = false;
 
             List<FederationWalker.SiteViews> siteViews = null;
             try
@@ -101,6 +113,7 @@ namespace FlexView.Client
 
             tree.Items.Clear();
             searchBox.IsEnabled = true;
+            refreshButton.IsEnabled = true;
 
             if (siteViews == null || siteViews.Count <= 1)
             {

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -20,13 +20,8 @@ namespace FlexView.Client
         public Item SelectedItem { get; private set; }
         public Item SelectedParent { get; private set; }
 
-        // TEST (federated views): true when the selected view lives on a different site than the
-        // master we are logged into. The caller then loads it as a new copy so it can be saved into
-        // a parent (master) folder rather than written back to the child site.
-        public bool SelectedIsCrossSite { get; private set; }
-
-        // TEST (federated views): set when the selection is a child-site view read from the
-        // Management Server config (rather than a master client Item). Carries the rebuilt FQID.
+        // Set when the selection is a child-site view read from the Management Server config
+        // (rather than a master client Item). Carries its captured layout XML for copying.
         internal FederationWalker.FedView SelectedFedView { get; private set; }
 
         public ViewBrowserWindow(BrowseMode mode) : this(mode, false) { }
@@ -122,13 +117,13 @@ namespace FlexView.Client
                 }
                 else
                 {
-                    // Child site: views read from the Management Server config. Each carries a rebuilt
-                    // FQID so it can be resolved to a ViewAndLayoutItem and opened as a copy, then
-                    // saved into a parent folder. Views whose FQID could not be rebuilt are shown but
-                    // not selectable.
+                    // Child site: views read from the Management Server config, each carrying its own
+                    // captured layout XML so it can be copied into a folder on this site without ever
+                    // needing a client-side handle to the source view. Views whose layout XML could
+                    // not be read are shown but not selectable.
                     foreach (var fv in sv.FedViews)
                     {
-                        bool openable = fv.Fqid != null;
+                        bool openable = fv.HasLayoutXml;
                         header.Items.Add(new TreeViewItem
                         {
                             Header = $"\U0001F4CB {fv.GroupPath} / {fv.Name}" + (openable ? "" : "   [not resolvable]"),
@@ -272,14 +267,13 @@ namespace FlexView.Client
             var selected = tree.SelectedItem as TreeViewItem;
             if (selected == null) return;
 
-            // TEST (federated views): a child-site view carries a FedView tag, not a client Item.
+            // A child-site view carries a FedView tag, not a client Item.
             if (selected.Tag is FederationWalker.FedView fv)
             {
                 SelectedFedView = fv;
                 SelectedItem = null;
                 SelectedParent = null;
-                SelectedIsCrossSite = true;
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Selected child-site view '{fv.Name}' on '{fv.SiteName}' (fqid={(fv.Fqid != null)})");
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Selected child-site view '{fv.Name}' on '{fv.SiteName}'");
                 DialogResult = true;
                 return;
             }
@@ -290,19 +284,6 @@ namespace FlexView.Client
             var parentNode = selected.Parent as TreeViewItem;
             if (parentNode != null)
                 SelectedParent = parentNode.Tag as Item;
-
-            // TEST (federated views): flag selections that live on a child site so the caller loads
-            // them as a copy targeted at a parent folder.
-            SelectedIsCrossSite = false;
-            try
-            {
-                var masterSid = EnvironmentManager.Instance.MasterSite?.ServerId?.Id;
-                var selSid = SelectedItem?.FQID?.ServerId?.Id;
-                if (masterSid != null && selSid != null && masterSid != selSid)
-                    SelectedIsCrossSite = true;
-                FlexViewDefinition.Log.Info($"[FlexViewFed] Selected '{SelectedItem?.Name}' kind={SelectedItem?.FQID?.Kind} crossSite={SelectedIsCrossSite}");
-            }
-            catch { }
 
             DialogResult = true;
         }

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -145,10 +145,11 @@ namespace FlexView.Client
 
                 if (sv.IsMaster)
                 {
-                    // Master: real client Items - fully selectable/openable, same as today.
-                    foreach (var root in sv.ClientViewRoots)
+                    // Master: real client Items, fully selectable/openable - built from the pre-fetched
+                    // ClientTree (no GetChildren() calls here) so a cache hit is pure in-memory work.
+                    foreach (var rootNode in sv.ClientTree)
                     {
-                        var node = CreateTreeNode(root);
+                        var node = CreateTreeNodeFromClientNode(rootNode);
                         if (node != null) { header.Items.Add(node); added++; }
                     }
                 }
@@ -186,6 +187,35 @@ namespace FlexView.Client
 
                 tree.Items.Add(header);
             }
+        }
+
+        // Builds a TreeViewItem straight from a pre-fetched ClientNode - no GetChildren() calls, since
+        // those were already resolved once when the site walk ran (see FederationWalker.BuildClientNode).
+        // This is what makes a cache hit actually fast: without it, rebuilding the master's ~113+ view
+        // group tree via live GetChildren() calls was still costing ~10 seconds on every Open View
+        // click, even after CollectAllSiteViews itself started returning instantly from cache.
+        private TreeViewItem CreateTreeNodeFromClientNode(FederationWalker.ClientNode node)
+        {
+            var item = node?.Item;
+            if (item == null) return null;
+
+            bool isFolder;
+            try { isFolder = item.FQID.FolderType != FolderType.No; } catch { isFolder = false; }
+
+            var treeViewItem = new TreeViewItem
+            {
+                Header = (isFolder ? "\U0001F4C1 " : "\U0001F4CB ") + item.Name,
+                Tag = item,
+                IsExpanded = true,
+            };
+
+            foreach (var child in node.Children)
+            {
+                var childNode = CreateTreeNodeFromClientNode(child);
+                if (childNode != null) treeViewItem.Items.Add(childNode);
+            }
+
+            return treeViewItem;
         }
 
         private TreeViewItem CreateTreeNode(Item item)

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
@@ -42,7 +43,7 @@ namespace FlexView.Client
         {
             if (_federated && _mode == BrowseMode.SelectView)
             {
-                LoadTreeFederated();
+                LoadTreeFederatedAsync();
                 return;
             }
             LoadTreeClassic();
@@ -71,27 +72,50 @@ namespace FlexView.Client
             }
         }
 
-        // TEST (federated views): one non-selectable header node per site, each holding that site's
-        // view roots. On a non-federated system (only the master) this falls back to the classic
-        // flat tree so behavior is unchanged.
-        private void LoadTreeFederated()
+        // One non-selectable header node per site, each holding that site's view roots. On a
+        // non-federated system (only the master) this falls back to the classic flat tree so
+        // behavior is unchanged. CollectAllSiteViews walks every site's config over the network -
+        // it previously ran synchronously in the constructor and froze the whole Smart Client host
+        // for as long as that took (over a minute on a real hierarchy), so it's offloaded to a
+        // background thread here and the tree is only populated once it completes.
+        private async void LoadTreeFederatedAsync()
         {
-            List<FederationWalker.SiteViews> siteViews;
-            try { siteViews = FederationWalker.CollectAllSiteViews(); }
+            var loadingNode = new TreeViewItem
+            {
+                Header = "Loading sites...",
+                Foreground = new SolidColorBrush(Color.FromRgb(0x8B, 0x94, 0x9E)),
+                IsEnabled = false
+            };
+            tree.Items.Add(loadingNode);
+            searchBox.IsEnabled = false;
+
+            List<FederationWalker.SiteViews> siteViews = null;
+            try
+            {
+                siteViews = await Task.Run(() => FederationWalker.CollectAllSiteViews());
+            }
             catch (Exception ex)
             {
                 FlexViewDefinition.Log.Info($"[FlexViewFed] CollectAllSiteViews failed: {ex.Message}");
-                LoadTreeClassic();
-                return;
             }
+
+            tree.Items.Clear();
+            searchBox.IsEnabled = true;
 
             if (siteViews == null || siteViews.Count <= 1)
             {
-                FlexViewDefinition.Log.Info("[FlexViewFed] Single site (no children) - using classic flat tree.");
+                FlexViewDefinition.Log.Info(siteViews == null
+                    ? "[FlexViewFed] CollectAllSiteViews failed - using classic flat tree."
+                    : "[FlexViewFed] Single site (no children) - using classic flat tree.");
                 LoadTreeClassic();
                 return;
             }
 
+            PopulateFederatedTree(siteViews);
+        }
+
+        private void PopulateFederatedTree(List<FederationWalker.SiteViews> siteViews)
+        {
             var dim = new SolidColorBrush(Color.FromRgb(0x8B, 0x94, 0x9E));
 
             foreach (var sv in siteViews)

--- a/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ViewBrowserWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Media;
 using VideoOS.Platform;
 using VideoOS.Platform.Client;
 
@@ -12,13 +13,24 @@ namespace FlexView.Client
     public partial class ViewBrowserWindow : Window
     {
         private readonly BrowseMode _mode;
+        // TEST (federated views): when true, the Open tree is populated from every site (master +
+        // federated children) via FederationWalker instead of the master-only client view tree.
+        private readonly bool _federated;
 
         public Item SelectedItem { get; private set; }
         public Item SelectedParent { get; private set; }
 
-        public ViewBrowserWindow(BrowseMode mode)
+        // TEST (federated views): true when the selected view lives on a different site than the
+        // master we are logged into. The caller then loads it as a new copy so it can be saved into
+        // a parent (master) folder rather than written back to the child site.
+        public bool SelectedIsCrossSite { get; private set; }
+
+        public ViewBrowserWindow(BrowseMode mode) : this(mode, false) { }
+
+        public ViewBrowserWindow(BrowseMode mode, bool federated)
         {
             _mode = mode;
+            _federated = federated;
             InitializeComponent();
             headerText.Text = mode == BrowseMode.SelectFolder
                 ? "Select a folder to save the view in"
@@ -28,6 +40,17 @@ namespace FlexView.Client
         }
 
         private void LoadTree()
+        {
+            if (_federated && _mode == BrowseMode.SelectView)
+            {
+                LoadTreeFederated();
+                return;
+            }
+            LoadTreeClassic();
+        }
+
+        // Master-only tree from the client view-group API (original behavior).
+        private void LoadTreeClassic()
         {
             List<Item> groups;
             try
@@ -46,6 +69,62 @@ namespace FlexView.Client
                 var node = CreateTreeNode(group);
                 if (node != null)
                     tree.Items.Add(node);
+            }
+        }
+
+        // TEST (federated views): one non-selectable header node per site, each holding that site's
+        // view roots. On a non-federated system (only the master) this falls back to the classic
+        // flat tree so behavior is unchanged.
+        private void LoadTreeFederated()
+        {
+            List<FederationWalker.SiteViews> siteViews;
+            try { siteViews = FederationWalker.CollectAllSiteViews(); }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewFed] CollectAllSiteViews failed: {ex.Message}");
+                LoadTreeClassic();
+                return;
+            }
+
+            if (siteViews == null || siteViews.Count <= 1)
+            {
+                FlexViewDefinition.Log.Info("[FlexViewFed] Single site (no children) - using classic flat tree.");
+                LoadTreeClassic();
+                return;
+            }
+
+            foreach (var sv in siteViews)
+            {
+                var header = new TreeViewItem
+                {
+                    Header = "\U0001F310 " + sv.Label,
+                    Tag = null,                 // site header is not selectable
+                    IsExpanded = true,
+                    FontWeight = FontWeights.Bold
+                };
+
+                int added = 0;
+                if (sv.ViewRoots != null)
+                {
+                    foreach (var root in sv.ViewRoots)
+                    {
+                        var node = CreateTreeNode(root);
+                        if (node != null) { header.Items.Add(node); added++; }
+                    }
+                }
+
+                if (added == 0)
+                {
+                    header.Items.Add(new TreeViewItem
+                    {
+                        Header = "   (no views reachable)",
+                        Foreground = new SolidColorBrush(Color.FromRgb(0x8B, 0x94, 0x9E)),
+                        Tag = null,
+                        FontWeight = FontWeights.Normal
+                    });
+                }
+
+                tree.Items.Add(header);
             }
         }
 
@@ -158,6 +237,19 @@ namespace FlexView.Client
             var parentNode = selected.Parent as TreeViewItem;
             if (parentNode != null)
                 SelectedParent = parentNode.Tag as Item;
+
+            // TEST (federated views): flag selections that live on a child site so the caller loads
+            // them as a copy targeted at a parent folder.
+            SelectedIsCrossSite = false;
+            try
+            {
+                var masterSid = EnvironmentManager.Instance.MasterSite?.ServerId?.Id;
+                var selSid = SelectedItem?.FQID?.ServerId?.Id;
+                if (masterSid != null && selSid != null && masterSid != selSid)
+                    SelectedIsCrossSite = true;
+                FlexViewDefinition.Log.Info($"[FlexViewFed] Selected '{SelectedItem?.Name}' kind={SelectedItem?.FQID?.Kind} crossSite={SelectedIsCrossSite}");
+            }
+            catch { }
 
             DialogResult = true;
         }


### PR DESCRIPTION
## Summary

Copying a view from a child site (in a Milestone Federated Architecture hierarchy) into a local View Group failed with "This view is on another site and could not be resolved through the current session", and browsing federated sites could take 90+ seconds and freeze the client.

**Root cause:** Views are not part of MFA's federated client-session model - `ClientControl`/`Configuration.Instance.GetItem` can never resolve a view living on a child site, unlike devices/cameras/alarms/access, which are genuinely federated.

**Fix:** read views directly off each site's Management Server configuration (`ManagementServer -> ViewGroupFolder -> ViewGroup -> ViewFolder -> View`) instead of the client session - this works uniformly for the master and every child site, since it doesn't depend on federation at the client layer at all. The copy is recreated via `ViewGroup.ViewFolder.AddView(...)` using the captured `LayoutViewItems` XML, then camera slots are restored afterward through the client session (`InsertBuiltinViewItem`, the only documented way to write per-slot content) - which now works because the destination is genuinely local.

A few real bugs turned up from testing this against a live 3 MGMT servers, with 130 view groups, all fixed along the way:
- `ViewGroup` is ambiguous between `VideoOS.Platform.Client` and `VideoOS.Platform.ConfigurationItems` (CS0104)
- `new ViewGroup(fqid)` throws `"Invalid kind for this constructor"` when the FQID comes from a client `Item` rather than the config-API's own object graph - the destination is now resolved by walking the tree and matching `Id` instead
- The site walk ran synchronously and could freeze Smart Client for the whole duration - now backgrounded, with the master's own view tree pre-fetched once instead of re-walked via live `GetChildren()` calls on every open
- Restoring camera slots must run on Smart Client's UI thread - doing it off-thread throws `"The calling thread cannot access this object because a different thread owns it"` on `Save()`
- The client's item cache doesn't see a view created through the raw config API immediately (`Configuration.RefreshConfiguration` explicitly excludes built-in types), so restoring cameras needs a bounded async retry
- A `Save()` failure was incorrectly zeroing out an already-successful camera restore in the reported count

**Also added:**
- Session-long caching of the site/view walk, with a manual Refresh button, so repeat browsing doesn't re-walk every site
- Batch copy: check several views across sites, pick one destination folder, one summary result instead of one dialog per view

## Test plan

- [x] Verified end-to-end against a real 3 MGMT Server hierarchy, 1 parent 2 children, 130 view groups.
- [x] Single-view copy from a child site into a local View Group, including camera slots
- [x] Batch copy of multiple views (from different sites/groups) into one destination in a single operation
- [x] Confirmed camera slots carry over correctly (e.g. 4/4, 12/12 cameras across different test views)
- [x] Confirmed the client no longer freezes while browsing federated sites
