### PR TITLE
feat(flexview): save arrangements as layouts, manage existing ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [3.4.30] - 2026-08-05
+- Add Flex View: **Save as Layout** - store the current pane arrangement as a reusable layout, offered in Smart Client setup mode under **Add View** alongside the built-in 1x1 and 2x2 templates. A layout stores geometry only - cameras and other view item content are not part of it, so a view created from one starts empty. The dialog previews exactly what will be stored, and a thumbnail of the arrangement is generated so the layout is recognisable in the picker.
+- Add Flex View: **Manage Layouts** - lists every layout defined on the site with its group, pane count and last-modified date, and deletes the selected one. Deletion is site-wide and cannot be undone. Views already built from a layout keep working, because each view holds its own copy of the arrangement.
+- Add Flex View: Copy views from federated child sites. Views are not part of Milestone Federated Architecture's client-session model, so a child-site view could never be resolved through the client session and the copy failed with "This view is on another site and could not be resolved through the current session". Views are now read directly from each site's Management Server configuration - which works uniformly for the master and every child site - and recreated locally with their camera slots restored. GH PR: #169
+- Add Flex View: Batch copy - check several views across sites, pick one destination folder, and get a single summary instead of one dialog per view.
+- Improve Flex View: The federated site and view walk is cached for the session with a manual **Refresh**, and the master's own view tree is pre-fetched once instead of being re-walked on every open. Browsing federated sites no longer freezes the client for 90 seconds or more.
+- Fix SC Remote Control: "Method not found: Swashbuckle.Application.HttpConfigurationExtensions.EnableSwagger" on machines running other MIP plugins. Swashbuckle.Core pins its AssemblyVersion at 1.0.0.0 in every package release, so two plugins shipping different builds present the same assembly identity, and in Smart Client's shared AppDomain whichever loads first wins for everyone. Swashbuckle is now merged and internalized into the plugin, so no shared identity is exposed. This only ever reproduced where a conflicting plugin was installed, which is why it looked machine-specific.
+- Improve Project: Applied the outstanding dependency updates - ILRepack 2.0.46, BouncyCastle.Cryptography 2.7.0, Microsoft.Web.WebView2 1.0.4078.44, and pymdown-extensions 11.0, which closes GHSA-9xwg-3r6f-jcx2 (path traversal in the b64 extension). LiveChartsCore is deliberately held at 2.0.0-rc5.4 and excluded from Dependabot, since the 2.0.x stable line has API drift not yet validated against the Metadata Display line chart.
+- Improve Project: The RTSPS test server's Dockerfile now pins both base images by digest, clearing the outstanding OpenSSF Scorecard pinned-dependency findings.
+- Improve Docs: Expanded the SC Remote Control documentation.
+
 ## [3.4.26] - 2026-06-27
 - Smart Bar: Fix large camera loading freezing it.
 

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml
@@ -95,6 +95,18 @@
                             Click="OnSaveClick" Margin="0,0,4,0"/>
                     <Button x:Name="saveAsButton" Content="&#x1F4DD; Save As" Style="{StaticResource AccentButton}"
                             Click="OnSaveAsClick" Visibility="Collapsed"/>
+
+                    <!-- Layout tools. Separated from the view buttons because they write shared
+                         server configuration rather than a view in a folder. -->
+                    <Border Width="1" Background="#FF30363D" Margin="8,4,8,4"/>
+                    <Button x:Name="saveLayoutButton" Content="&#x1F4D0; Save as Layout"
+                            Style="{StaticResource ToolButton}"
+                            Click="OnSaveAsLayoutClick" Margin="0,0,4,0"
+                            ToolTip="Store this arrangement as a reusable layout in Add View. Panes only, no cameras."/>
+                    <Button x:Name="manageLayoutsButton" Content="&#x2699; Manage Layouts"
+                            Style="{StaticResource ToolButton}"
+                            Click="OnManageLayoutsClick"
+                            ToolTip="List and delete the layouts defined on this site."/>
                 </StackPanel>
                 <TextBlock x:Name="viewNameLabel" Foreground="#FF58A6FF" FontSize="12"
                            VerticalAlignment="Center" HorizontalAlignment="Left" FontWeight="SemiBold"/>

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -819,8 +819,15 @@ namespace FlexView.Client
 
         private void ShowSavedStatus(string viewName)
         {
+            FlashStatus($"Saved \"{viewName}\"");
+        }
+
+        // Green confirmation in the status corner that reverts to the normal pane/grid readout
+        // after three seconds.
+        private void FlashStatus(string message)
+        {
             var original = statusText.Foreground;
-            statusText.Text = $"Saved \"{viewName}\"";
+            statusText.Text = message;
             statusText.Foreground = new SolidColorBrush((Color)ColorConverter.ConvertFromString("#FF4CAF50"));
 
             var timer = new System.Windows.Threading.DispatcherTimer { Interval = TimeSpan.FromSeconds(3) };
@@ -1670,6 +1677,153 @@ namespace FlexView.Client
             _isDirty = false;
             viewNameLabel.Text = newView.Name;
             UpdateStatus();
+        }
+
+        #endregion
+
+        #region Layouts
+
+        // Stores the current arrangement as a layout: a reusable template in Smart Client's Add View
+        // picker, alongside the built-in 1x1 / 2x2 grids.
+        //
+        // A layout is geometry and nothing else - the SDK's Layout type carries only Id, Name,
+        // Description and DefinitionXml, with no way to attach cameras. Views created from this
+        // layout therefore start empty. SaveLayoutWindow states that on the dialog, and the button
+        // is worded "Save as Layout" rather than "Save View as Layout" for the same reason.
+        //
+        // The rectangles come from ConvertPanesToSdkLayout, the same method the view save path uses,
+        // and land in the definition XML unscaled: both sides are the 0..1000 coordinate space, so
+        // what the operator drew is stored exactly.
+        private async void OnSaveAsLayoutClick(object sender, RoutedEventArgs e)
+        {
+            if (_panes.Count == 0)
+            {
+                MessageDialog.ShowError("Cannot Save Layout",
+                    "Create at least one pane before saving a layout.", Window.GetWindow(this));
+                return;
+            }
+
+            // Panes cannot overlap by construction - every create, move and resize is rejected on
+            // overlap. Checked anyway because an overlapping layout would be accepted by the server
+            // and only misbehave later, in the picker, far from here.
+            var overlapping = _panes.Where(HasOverlap).ToList();
+            if (overlapping.Count > 0)
+            {
+                FlexViewDefinition.Log.Error(
+                    $"[FlexViewLayout] Save as Layout refused: {overlapping.Count} overlapping pane(s) - "
+                    + string.Join(", ", overlapping.Select(p => $"#{p.Id}({p.Col},{p.Row},{p.ColSpan}x{p.RowSpan})")));
+                MessageDialog.ShowError("Cannot Save Layout",
+                    "Some panes overlap. Separate them before saving as a layout.", Window.GetWindow(this));
+                return;
+            }
+
+            var rects = ConvertPanesToSdkLayout();
+            FlexViewDefinition.Log.Info(
+                $"[FlexViewLayout] Save as Layout: {rects.Length} pane(s) - "
+                + string.Join(" ", rects.Select(r => $"({r.X},{r.Y},{r.Width}x{r.Height})")));
+
+            List<LayoutRepository.LayoutGroupInfo> groups;
+            SetLayoutButtonsEnabled(false);
+            try
+            {
+                groups = await Task.Run(() => LayoutRepository.LoadGroups());
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] Save as Layout: loading groups failed - {ex.GetType().Name}: {ex.Message}", ex);
+                MessageDialog.ShowError("Cannot Save Layout",
+                    $"The layout groups could not be read from the management server:\n\n{ex.Message}\n\n"
+                    + "Saving a layout needs configuration rights that a standard operator account usually does not have. "
+                    + "See MIPLog for details.",
+                    Window.GetWindow(this));
+                return;
+            }
+            finally
+            {
+                SetLayoutButtonsEnabled(true);
+            }
+
+            var defaultName = _isEditMode && _editingView != null && !string.IsNullOrWhiteSpace(_editingView.Name)
+                ? _editingView.Name
+                : $"FlexView {_panes.Count} pane{(_panes.Count != 1 ? "s" : "")}";
+
+            var dlg = new SaveLayoutWindow(defaultName, groups, rects) { Owner = Application.Current.MainWindow };
+            if (dlg.ShowDialog() != true)
+            {
+                FlexViewDefinition.Log.Info("[FlexViewLayout] Save as Layout cancelled by the operator.");
+                return;
+            }
+
+            var group = dlg.SelectedGroup;
+            var name = dlg.LayoutName;
+            var description = dlg.LayoutDescription;
+
+            // Rendered here, on the UI thread: RenderTargetBitmap needs a Dispatcher, so it cannot
+            // move into the Task.Run below.
+            var icon = LayoutIconRenderer.RenderBase64(rects);
+
+            string definitionXml;
+            try
+            {
+                definitionXml = LayoutRepository.BuildDefinitionXml(rects, icon);
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] Save as Layout: building definition xml failed - {ex.GetType().Name}: {ex.Message}", ex);
+                MessageDialog.ShowError("Cannot Save Layout",
+                    $"The layout definition could not be built:\n\n{ex.Message}", Window.GetWindow(this));
+                return;
+            }
+
+            SetLayoutButtonsEnabled(false);
+            statusText.Text = $"Saving layout \"{name}\"...";
+            try
+            {
+                await Task.Run(() => LayoutRepository.AddLayout(group, name, description, definitionXml));
+
+                FlashStatus($"Saved layout \"{name}\"");
+                MessageDialog.ShowSuccess("Layout Saved",
+                    $"\"{name}\" was added to the \"{group.Name}\" group.\n\n"
+                    + "It is now available in Smart Client setup mode under Add View. Views created from it "
+                    + "start empty - the arrangement is stored, the cameras are not.",
+                    Window.GetWindow(this));
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] Save as Layout: AddLayout failed - {ex.GetType().Name}: {ex.Message}", ex);
+                UpdateStatus();
+                MessageDialog.ShowError("Save Layout Failed",
+                    $"\"{name}\" could not be saved:\n\n{ex.Message}\n\nSee MIPLog for the full detail.",
+                    Window.GetWindow(this));
+            }
+            finally
+            {
+                SetLayoutButtonsEnabled(true);
+            }
+        }
+
+        private void OnManageLayoutsClick(object sender, RoutedEventArgs e)
+        {
+            try
+            {
+                FlexViewDefinition.Log.Info("[FlexViewLayout] Manage Layouts opened.");
+                var dlg = new ManageLayoutsWindow { Owner = Application.Current.MainWindow };
+                dlg.ShowDialog();
+                FlexViewDefinition.Log.Info("[FlexViewLayout] Manage Layouts closed.");
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] Manage Layouts failed to open - {ex.GetType().Name}: {ex.Message}", ex);
+                MessageDialog.ShowError("Manage Layouts Failed",
+                    $"The layout manager could not be opened:\n\n{ex.Message}\n\nSee MIPLog for details.",
+                    Window.GetWindow(this));
+            }
+        }
+
+        private void SetLayoutButtonsEnabled(bool enabled)
+        {
+            saveLayoutButton.IsEnabled = enabled;
+            manageLayoutsButton.IsEnabled = enabled;
         }
 
         #endregion

--- a/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/FlexViewViewItemWpfUserControl.xaml.cs
@@ -1756,7 +1756,6 @@ namespace FlexView.Client
 
             var group = dlg.SelectedGroup;
             var name = dlg.LayoutName;
-            var description = dlg.LayoutDescription;
 
             // Rendered here, on the UI thread: RenderTargetBitmap needs a Dispatcher, so it cannot
             // move into the Task.Run below.
@@ -1779,7 +1778,13 @@ namespace FlexView.Client
             statusText.Text = $"Saving layout \"{name}\"...";
             try
             {
-                await Task.Run(() => LayoutRepository.AddLayout(group, name, description, definitionXml));
+                // AddLayout's description is required by the SDK signature but nothing in the
+                // picker surfaces it, so it is not worth a field on the dialog.
+                await Task.Run(() => LayoutRepository.AddLayout(group, name, "", definitionXml));
+
+                // Without this the layout is on the server but absent from Add View until the
+                // operator reloads the client by hand, which reads as the save having failed.
+                LayoutRepository.RequestClientConfigurationReload();
 
                 FlashStatus($"Saved layout \"{name}\"");
                 MessageDialog.ShowSuccess("Layout Saved",

--- a/Smart Client Plugins/FlexView/Client/LayoutIconRenderer.cs
+++ b/Smart Client Plugins/FlexView/Client/LayoutIconRenderer.cs
@@ -16,7 +16,10 @@ namespace FlexView.Client
     // thread. Callers render first, then hand the resulting base64 string to the background save.
     internal static class LayoutIconRenderer
     {
-        private const int IconPixels = 64;
+        // 16x16 to match the built-in layout icons. The picker draws the bitmap at its native size
+        // rather than scaling it to the row, so a larger icon does not render sharper - it stretches
+        // the row it sits in and towers over the 1x1 / 2x2 / 3x3 entries beside it.
+        private const int IconPixels = 16;
 
         // Mid-tone fill deliberately: the picker background differs between Smart Client themes, and
         // a mid grey stays legible against both rather than disappearing into one of them.
@@ -47,20 +50,29 @@ namespace FlexView.Client
                     pen.Freeze();
 
                     var any = false;
+                    const double scale = (double)IconPixels / LayoutRepository.SdkMax;
+
                     foreach (var r in rects)
                     {
                         any = true;
-                        var scale = (double)IconPixels / LayoutRepository.SdkMax;
+
+                        // Round each edge independently rather than rounding position and size
+                        // separately. At 16px a 5% pane is well under one pixel, and rounding the
+                        // size on its own collapses it to zero - the pane would silently vanish
+                        // from the icon while still existing in the layout.
+                        var x0 = Math.Round(r.X * scale);
+                        var y0 = Math.Round(r.Y * scale);
+                        var x1 = Math.Round((r.X + r.Width) * scale);
+                        var y1 = Math.Round((r.Y + r.Height) * scale);
 
                         // Half-pixel offset keeps the 1px stroke on a device pixel instead of
-                        // straddling two, which otherwise renders as a soft 2px smear at this size.
-                        var x = Math.Round(r.X * scale) + 0.5;
-                        var y = Math.Round(r.Y * scale) + 0.5;
-                        var w = Math.Round(r.Width * scale) - 1.0;
-                        var h = Math.Round(r.Height * scale) - 1.0;
+                        // straddling two, which otherwise renders as a soft 2px smear. Insetting by
+                        // one leaves a hairline between neighbours, which is what separates the
+                        // panes visually at this size.
+                        var w = Math.Max(1.0, x1 - x0 - 1.0);
+                        var h = Math.Max(1.0, y1 - y0 - 1.0);
 
-                        if (w <= 0 || h <= 0) continue;
-                        dc.DrawRectangle(PaneFill, pen, new Rect(x, y, w, h));
+                        dc.DrawRectangle(PaneFill, pen, new Rect(x0 + 0.5, y0 + 0.5, w, h));
                     }
 
                     if (!any) return null;

--- a/Smart Client Plugins/FlexView/Client/LayoutIconRenderer.cs
+++ b/Smart Client Plugins/FlexView/Client/LayoutIconRenderer.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using SdkRectangle = System.Drawing.Rectangle;
+
+namespace FlexView.Client
+{
+    // Renders the thumbnail shown next to a layout in Smart Client's Add View picker. A layout
+    // without a ViewLayoutIcon shows up blank there, which makes a set of saved layouts impossible
+    // to tell apart, so one is always generated.
+    //
+    // RenderTargetBitmap needs an STA thread with a Dispatcher, so this must be called on the UI
+    // thread. Callers render first, then hand the resulting base64 string to the background save.
+    internal static class LayoutIconRenderer
+    {
+        private const int IconPixels = 64;
+
+        // Mid-tone fill deliberately: the picker background differs between Smart Client themes, and
+        // a mid grey stays legible against both rather than disappearing into one of them.
+        private static readonly Brush PaneFill = new SolidColorBrush(Color.FromRgb(0x8B, 0x94, 0x9E));
+        private static readonly Brush PaneStroke = new SolidColorBrush(Color.FromRgb(0x30, 0x36, 0x3D));
+
+        static LayoutIconRenderer()
+        {
+            PaneFill.Freeze();
+            PaneStroke.Freeze();
+        }
+
+        // Returns a base64 PNG of the arrangement, or null if rendering fails. A missing icon is a
+        // cosmetic loss, never a reason to abort the save, so failures are logged and swallowed.
+        public static string RenderBase64(IEnumerable<SdkRectangle> rects)
+        {
+            try
+            {
+                if (rects == null) return null;
+
+                var visual = new DrawingVisual();
+                using (var dc = visual.RenderOpen())
+                {
+                    // Transparent background so the picker's own backdrop shows through.
+                    dc.DrawRectangle(Brushes.Transparent, null, new Rect(0, 0, IconPixels, IconPixels));
+
+                    var pen = new Pen(PaneStroke, 1.0);
+                    pen.Freeze();
+
+                    var any = false;
+                    foreach (var r in rects)
+                    {
+                        any = true;
+                        var scale = (double)IconPixels / LayoutRepository.SdkMax;
+
+                        // Half-pixel offset keeps the 1px stroke on a device pixel instead of
+                        // straddling two, which otherwise renders as a soft 2px smear at this size.
+                        var x = Math.Round(r.X * scale) + 0.5;
+                        var y = Math.Round(r.Y * scale) + 0.5;
+                        var w = Math.Round(r.Width * scale) - 1.0;
+                        var h = Math.Round(r.Height * scale) - 1.0;
+
+                        if (w <= 0 || h <= 0) continue;
+                        dc.DrawRectangle(PaneFill, pen, new Rect(x, y, w, h));
+                    }
+
+                    if (!any) return null;
+                }
+
+                var bitmap = new RenderTargetBitmap(IconPixels, IconPixels, 96, 96, PixelFormats.Pbgra32);
+                bitmap.Render(visual);
+
+                var encoder = new PngBitmapEncoder();
+                encoder.Frames.Add(BitmapFrame.Create(bitmap));
+
+                using (var ms = new MemoryStream())
+                {
+                    encoder.Save(ms);
+                    var base64 = Convert.ToBase64String(ms.ToArray());
+                    FlexViewDefinition.Log.Info($"[FlexViewLayout] RenderIcon: {IconPixels}x{IconPixels} png, {ms.Length} bytes, {base64.Length} base64 chars.");
+                    return base64;
+                }
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] RenderIcon failed - {ex.GetType().Name}: {ex.Message}. Layout will be saved without a thumbnail.", ex);
+                return null;
+            }
+        }
+
+        // Same drawing, returned as a live ImageSource for the Save As Layout preview. Kept separate
+        // from RenderBase64 so the preview can be sized independently of the stored 64px icon.
+        public static ImageSource RenderPreview(IEnumerable<SdkRectangle> rects, int pixelWidth, int pixelHeight)
+        {
+            try
+            {
+                if (rects == null) return null;
+
+                var visual = new DrawingVisual();
+                using (var dc = visual.RenderOpen())
+                {
+                    dc.DrawRectangle(new SolidColorBrush(Color.FromRgb(0x05, 0x08, 0x11)), null,
+                        new Rect(0, 0, pixelWidth, pixelHeight));
+
+                    var pen = new Pen(PaneStroke, 1.0);
+                    pen.Freeze();
+
+                    foreach (var r in rects)
+                    {
+                        var x = Math.Round(r.X * (double)pixelWidth / LayoutRepository.SdkMax) + 0.5;
+                        var y = Math.Round(r.Y * (double)pixelHeight / LayoutRepository.SdkMax) + 0.5;
+                        var w = Math.Round(r.Width * (double)pixelWidth / LayoutRepository.SdkMax) - 1.0;
+                        var h = Math.Round(r.Height * (double)pixelHeight / LayoutRepository.SdkMax) - 1.0;
+
+                        if (w <= 0 || h <= 0) continue;
+                        dc.DrawRectangle(PaneFill, pen, new Rect(x, y, w, h));
+                    }
+                }
+
+                var bitmap = new RenderTargetBitmap(pixelWidth, pixelHeight, 96, 96, PixelFormats.Pbgra32);
+                bitmap.Render(visual);
+                bitmap.Freeze();
+                return bitmap;
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] RenderPreview failed - {ex.GetType().Name}: {ex.Message}", ex);
+                return null;
+            }
+        }
+    }
+}

--- a/Smart Client Plugins/FlexView/Client/LayoutRepository.cs
+++ b/Smart Client Plugins/FlexView/Client/LayoutRepository.cs
@@ -233,7 +233,8 @@ namespace FlexView.Client
                     $"The server's removable-layout list does not contain '{layout.Name}'. See MIPLog for the full list it returned.");
             }
 
-            Log.Info($"{P} RemoveLayout: selected '{selection}'.");
+            var side = choices.Any(kv => kv.Value == selection) ? "value" : "key";
+            Log.Info($"{P} RemoveLayout: submitting ItemSelection='{selection}' (the {side} side of the pair).");
             task.ItemSelection = selection;
 
             var result = task.Execute();
@@ -243,8 +244,16 @@ namespace FlexView.Client
             Log.Info($"{P} RemoveLayout: '{layout.Name}' removed from group '{layout.GroupName}'.");
         }
 
-        // The dictionary's key/value orientation is not contractual across versions, so both sides are
-        // matched, strongest identifier first: path, then id, then name.
+        // Picks the token to hand back as ItemSelection.
+        //
+        // On 26.1 the dictionary is {display name -> item path}: key='FlexView 3 panes',
+        // value='Layout[629cb03d-...]'. The server wants the path. Submitting the key gets
+        // ArgumentMIPException("itemSelection") straight back.
+        //
+        // The orientation is not contractual across versions though, so rather than hard-coding
+        // "always send the value", both sides are matched against the layout's own identifiers and
+        // whichever side IS the identifier gets submitted. The display name is never submitted -
+        // it is only ever used to find the pair.
         private static string ResolveSelection(IDictionary<string, string> choices, LayoutInfo layout)
         {
             foreach (var probe in new[] { layout.Path, layout.Id })
@@ -252,32 +261,36 @@ namespace FlexView.Client
                 if (string.IsNullOrEmpty(probe)) continue;
                 foreach (var kv in choices)
                 {
+                    if (string.Equals(kv.Value, probe, StringComparison.OrdinalIgnoreCase)) return kv.Value;
                     if (string.Equals(kv.Key, probe, StringComparison.OrdinalIgnoreCase)) return kv.Key;
-                    if (string.Equals(kv.Value, probe, StringComparison.OrdinalIgnoreCase)) return kv.Key;
                 }
             }
 
-            // Id can appear embedded in a longer path-style key, e.g. "Layout[<guid>]".
-            foreach (var probe in new[] { layout.Id, layout.Path })
+            // Id embedded in a longer path-style token, e.g. "Layout[<guid>]".
+            if (!string.IsNullOrEmpty(layout.Id))
             {
-                if (string.IsNullOrEmpty(probe)) continue;
                 foreach (var kv in choices)
                 {
-                    if (kv.Key != null && kv.Key.IndexOf(probe, StringComparison.OrdinalIgnoreCase) >= 0) return kv.Key;
-                    if (kv.Value != null && kv.Value.IndexOf(probe, StringComparison.OrdinalIgnoreCase) >= 0) return kv.Key;
+                    if (kv.Value != null && kv.Value.IndexOf(layout.Id, StringComparison.OrdinalIgnoreCase) >= 0) return kv.Value;
+                    if (kv.Key != null && kv.Key.IndexOf(layout.Id, StringComparison.OrdinalIgnoreCase) >= 0) return kv.Key;
                 }
             }
 
-            // Name last: it is the weakest match, so it is only accepted when it is unambiguous.
+            // Name last: the weakest match, accepted only when unambiguous, and even then what gets
+            // submitted is the opposite side of the pair - the identifier, not the name itself.
             if (!string.IsNullOrEmpty(layout.Name))
             {
                 var byName = choices
-                    .Where(kv => string.Equals(kv.Value, layout.Name, StringComparison.OrdinalIgnoreCase)
-                              || string.Equals(kv.Key, layout.Name, StringComparison.OrdinalIgnoreCase))
-                    .Select(kv => kv.Key)
+                    .Where(kv => string.Equals(kv.Key, layout.Name, StringComparison.OrdinalIgnoreCase)
+                              || string.Equals(kv.Value, layout.Name, StringComparison.OrdinalIgnoreCase))
                     .ToList();
 
-                if (byName.Count == 1) return byName[0];
+                if (byName.Count == 1)
+                {
+                    var kv = byName[0];
+                    return string.Equals(kv.Key, layout.Name, StringComparison.OrdinalIgnoreCase) ? kv.Value : kv.Key;
+                }
+
                 if (byName.Count > 1)
                     Log.Info($"{P} RemoveLayout: name '{layout.Name}' matched {byName.Count} candidates, refusing to guess.");
             }
@@ -336,6 +349,51 @@ namespace FlexView.Client
             }
 
             Log.Info($"{P} {what}: completed - state={task.State} progress={task.Progress} after {polls} poll(s).");
+        }
+
+        // Add and Remove write straight to the Management Server through the configuration API, a
+        // side channel the running Smart Client's own configuration is never notified about. Until
+        // the client re-reads it, a new layout is missing from Add View and a deleted one is still
+        // offered - which reads as the operation having silently failed.
+        //
+        // Reaching for something narrower than a full reload is the obvious instinct here. There
+        // isn't one, and the reason is worth writing down so it does not get re-litigated:
+        //
+        //   - ClearChildrenCache above clears the cache on our own ManagementServer instance. That
+        //     is what makes Manage Layouts show the truth. It says nothing to the client.
+        //   - Configuration.RefreshConfiguration(Kind.Layout) compiles - Kind.Layout exists - but
+        //     Milestone Development have confirmed it is a no-op for built-in kinds: "RefreshConfiguration
+        //     only works for plugin configurations... Any build-in item configuration is maintained
+        //     by the environment and thus cannot be refreshed through MIP."
+        //     https://forum.milestonesys.com/t/12005/6
+        //   - Even if it did work it would flush the wrong cache. It clears Configuration.Instance,
+        //     the MIP item cache a plugin reads through GetItemsByKind. The Add View picker is
+        //     native Smart Client UI reading the client's own configuration, which is a different
+        //     cache. ColoredTimeline's RefreshConfiguration call is not a counter-example: it passes
+        //     a plugin-defined kind and then re-reads through Configuration.Instance itself, so it
+        //     refreshes and reads the same cache.
+        //
+        // The client-wide reload is the only thing that reaches the cache the picker actually uses,
+        // and it is precisely what the operator would otherwise trigger by hand through Reload
+        // Configuration. It is coarse by necessity, not by shortcut - so callers should send it once
+        // per batch of changes rather than once per change.
+        public static void RequestClientConfigurationReload()
+        {
+            try
+            {
+                Log.Info($"{P} Requesting a Smart Client configuration reload so the layout picker picks the change up.");
+                EnvironmentManager.Instance.SendMessage(
+                    new VideoOS.Platform.Messaging.Message(
+                        VideoOS.Platform.Messaging.MessageId.SmartClient.ReloadConfigurationCommand));
+                Log.Info($"{P} Reload command sent.");
+            }
+            catch (Exception ex)
+            {
+                // Not fatal: the write already succeeded on the server. It only means the operator
+                // has to reload by hand before the change shows up in Add View.
+                Log.Error($"{P} Reload command failed - {ex.GetType().Name}: {ex.Message}. "
+                        + "Add View may stay stale until the client reloads its configuration manually.", ex);
+            }
         }
 
         private static void TryClearCache(ConfigItems.LayoutFolder folder, string what)

--- a/Smart Client Plugins/FlexView/Client/LayoutRepository.cs
+++ b/Smart Client Plugins/FlexView/Client/LayoutRepository.cs
@@ -1,0 +1,468 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using VideoOS.Platform;
+using ConfigItems = VideoOS.Platform.ConfigurationItems;
+using SdkRectangle = System.Drawing.Rectangle;
+
+namespace FlexView.Client
+{
+    // Every Management Server layout operation FlexView performs. Layouts are the templates
+    // offered in Smart Client setup mode under Add View, next to the built-in 1x1 / 2x2 grids.
+    //
+    // A Layout carries geometry and nothing else - the type exposes only Id, Name, Description
+    // and DefinitionXml. There is no camera collection on it and no way to attach one, so a
+    // layout saved from a populated FlexView arrangement is an empty template of the same shape.
+    // Every user-facing string in the UI is worded to make that explicit; see SaveLayoutWindow.
+    //
+    // Layouts are system-wide Management Server configuration, not per-user client state. Adding
+    // or removing one affects every operator on the site and needs configuration write rights that
+    // a normal Smart Client account usually does not have. That is why CanRead() exists as a cheap
+    // read-only probe the UI runs before offering either button, and why every failure path here
+    // logs the underlying exception rather than only surfacing a message box.
+    //
+    // All logging uses the [FlexViewLayout] prefix, matching FederationWalker's [FlexViewFed], so a
+    // customer MIPLog can be filtered down to just this feature.
+    internal static class LayoutRepository
+    {
+        private const string P = "[FlexViewLayout]";
+
+        // The layout XML coordinate space. Matches ViewAndLayoutItem.Layout / the SdkMax constant in
+        // FlexViewViewItemWpfUserControl, which is why a pane rectangle needs no scaling on the way
+        // out - both are 0..1000 on each axis.
+        internal const int SdkMax = 1000;
+
+        private static readonly TimeSpan TaskTimeout = TimeSpan.FromSeconds(30);
+
+        private static CommunitySDK.PluginLog Log => FlexViewDefinition.Log;
+
+        #region Models
+
+        // A snapshot of one layout group and its layouts, detached from the config API objects so the
+        // UI can bind to it after the background load completes. Group is kept because RemoveLayout
+        // has to be invoked on the owning LayoutFolder.
+        //
+        // Properties rather than fields throughout both models, and this is load-bearing: WPF data
+        // binding resolves through the property system only. A bound field does not raise an error,
+        // it renders as an empty cell, so ManageLayoutsWindow's Layout and Description columns came
+        // up blank while the computed-property columns beside them worked.
+        internal sealed class LayoutGroupInfo
+        {
+            public string Name { get; set; }
+            public string Id { get; set; }
+            public string Path { get; set; }
+            public ConfigItems.LayoutGroup Group { get; set; }
+            public List<LayoutInfo> Layouts { get; } = new List<LayoutInfo>();
+
+            // Set when this group's layouts could not be enumerated. One unreadable group must not
+            // blank out the whole Manage Layouts list, so the failure is carried per group instead
+            // of thrown.
+            public string LoadError { get; set; }
+
+            public override string ToString() => Name;
+        }
+
+        internal sealed class LayoutInfo
+        {
+            public string Name { get; set; }
+            public string Id { get; set; }
+            public string Path { get; set; }
+            public string Description { get; set; }
+            public int PaneCount { get; set; }
+            public DateTime LastModified { get; set; }
+            public LayoutGroupInfo Owner { get; set; }
+
+            public string GroupName => Owner?.Name ?? "";
+            public string PaneText => PaneCount > 0 ? PaneCount.ToString(CultureInfo.InvariantCulture) : "?";
+            public string ModifiedText => LastModified == DateTime.MinValue
+                ? ""
+                : LastModified.ToLocalTime().ToString("yyyy-MM-dd HH:mm", CultureInfo.InvariantCulture);
+        }
+
+        #endregion
+
+        #region Read
+
+        // Enumerates every layout group and the layouts inside it. Throws only when the server
+        // itself is unreachable; a group that fails to enumerate is returned with LoadError set.
+        public static List<LayoutGroupInfo> LoadGroups()
+        {
+            var started = DateTime.UtcNow;
+            Log.Info($"{P} LoadGroups: starting.");
+
+            var master = EnvironmentManager.Instance.MasterSite;
+            if (master == null)
+                throw new InvalidOperationException("Master site is not available. Is the client still connecting?");
+
+            var ms = new ConfigItems.ManagementServer(master);
+            var groupFolder = ms.LayoutGroupFolder;
+            if (groupFolder == null)
+                throw new InvalidOperationException("The management server returned no layout group folder.");
+
+            var groups = groupFolder.LayoutGroups;
+            if (groups == null)
+                throw new InvalidOperationException("The management server returned no layout groups.");
+
+            var result = new List<LayoutGroupInfo>();
+            foreach (var g in groups)
+            {
+                if (g == null) continue;
+
+                var info = new LayoutGroupInfo
+                {
+                    Name = SafeGet(() => g.Name) ?? "(unnamed group)",
+                    Id = SafeGet(() => g.Id),
+                    Path = SafeGet(() => g.Path),
+                    Group = g
+                };
+
+                try
+                {
+                    var folder = g.LayoutFolder;
+                    if (folder == null)
+                    {
+                        info.LoadError = "Group exposes no layout folder.";
+                        Log.Info($"{P} LoadGroups: group '{info.Name}' has no LayoutFolder.");
+                    }
+                    else
+                    {
+                        var layouts = folder.Layouts;
+                        if (layouts != null)
+                        {
+                            foreach (var l in layouts)
+                            {
+                                if (l == null) continue;
+                                var xml = SafeGet(() => l.DefinitionXml);
+                                info.Layouts.Add(new LayoutInfo
+                                {
+                                    Name = SafeGet(() => l.Name) ?? "(unnamed layout)",
+                                    Id = SafeGet(() => l.Id),
+                                    Path = SafeGet(() => l.Path),
+                                    Description = SafeGet(() => l.Description) ?? "",
+                                    PaneCount = CountPanes(xml),
+                                    LastModified = SafeGetDate(() => l.LastModified),
+                                    Owner = info
+                                });
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    info.LoadError = ex.Message;
+                    Log.Error($"{P} LoadGroups: group '{info.Name}' failed to enumerate - {ex.GetType().Name}: {ex.Message}", ex);
+                }
+
+                Log.Info($"{P} LoadGroups: group '{info.Name}' id={info.Id} path={info.Path} layouts={info.Layouts.Count}"
+                         + (info.LoadError != null ? $" error='{info.LoadError}'" : ""));
+                result.Add(info);
+            }
+
+            var elapsed = (DateTime.UtcNow - started).TotalMilliseconds;
+            Log.Info($"{P} LoadGroups: done - {result.Count} group(s), {result.Sum(g => g.Layouts.Count)} layout(s), {elapsed:F0} ms.");
+            return result;
+        }
+
+        #endregion
+
+        #region Write
+
+        // Creates a layout in the given group. The name is not checked for collisions first: the
+        // server enforces its own rules and reports them through the ServerTask, and reproducing
+        // that check here would only add a second, weaker source of truth.
+        public static void AddLayout(LayoutGroupInfo group, string name, string description, string definitionXml)
+        {
+            if (group == null) throw new ArgumentNullException(nameof(group));
+            if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Layout name is required.", nameof(name));
+            if (string.IsNullOrWhiteSpace(definitionXml)) throw new ArgumentException("Layout definition is required.", nameof(definitionXml));
+
+            var folder = group.Group?.LayoutFolder;
+            if (folder == null)
+                throw new InvalidOperationException($"Layout group '{group.Name}' exposes no layout folder to write to.");
+
+            Log.Info($"{P} AddLayout: group='{group.Name}' name='{name}' descriptionLength={description?.Length ?? 0} xmlLength={definitionXml.Length}");
+            Log.Info($"{P} AddLayout: definition xml =\n{Truncate(definitionXml, 2000)}");
+
+            var task = folder.AddLayout(name, description ?? "", definitionXml);
+            WaitForTask(task, $"AddLayout '{name}'");
+
+            // Without this the next Manage Layouts open would re-serve the pre-add cached collection
+            // and the new layout would look like it had silently failed.
+            TryClearCache(folder, "AddLayout");
+            Log.Info($"{P} AddLayout: '{name}' created in group '{group.Name}'.");
+        }
+
+        // Deletes a layout. The server exposes this as a task whose ItemSelectionValues dictionary
+        // lists what may be removed, so the selection key is resolved out of that dictionary rather
+        // than assumed to be the layout path - the whole dictionary is logged, which is the only way
+        // to diagnose a mismatch on a customer system.
+        public static void RemoveLayout(LayoutInfo layout)
+        {
+            if (layout == null) throw new ArgumentNullException(nameof(layout));
+
+            var folder = layout.Owner?.Group?.LayoutFolder;
+            if (folder == null)
+                throw new InvalidOperationException($"Layout '{layout.Name}' has no owning layout folder to remove it from.");
+
+            Log.Info($"{P} RemoveLayout: name='{layout.Name}' id={layout.Id} path={layout.Path} group='{layout.GroupName}'");
+
+            var task = folder.RemoveLayout();
+            if (task == null)
+                throw new InvalidOperationException("The management server returned no remove-layout task.");
+
+            var choices = task.ItemSelectionValues;
+            if (choices == null || choices.Count == 0)
+            {
+                Log.Error($"{P} RemoveLayout: server offered no removable items for group '{layout.GroupName}'.");
+                throw new InvalidOperationException(
+                    "The server did not offer this layout for removal. It may be a built-in layout, or the account may lack configuration rights.");
+            }
+
+            foreach (var kv in choices)
+                Log.Info($"{P} RemoveLayout: candidate key='{kv.Key}' value='{kv.Value}'");
+
+            var selection = ResolveSelection(choices, layout);
+            if (selection == null)
+            {
+                Log.Error($"{P} RemoveLayout: no candidate matched layout '{layout.Name}' (id={layout.Id}, path={layout.Path}). Candidates logged above.");
+                throw new InvalidOperationException(
+                    $"The server's removable-layout list does not contain '{layout.Name}'. See MIPLog for the full list it returned.");
+            }
+
+            Log.Info($"{P} RemoveLayout: selected '{selection}'.");
+            task.ItemSelection = selection;
+
+            var result = task.Execute();
+            WaitForTask(result, $"RemoveLayout '{layout.Name}'");
+
+            TryClearCache(folder, "RemoveLayout");
+            Log.Info($"{P} RemoveLayout: '{layout.Name}' removed from group '{layout.GroupName}'.");
+        }
+
+        // The dictionary's key/value orientation is not contractual across versions, so both sides are
+        // matched, strongest identifier first: path, then id, then name.
+        private static string ResolveSelection(IDictionary<string, string> choices, LayoutInfo layout)
+        {
+            foreach (var probe in new[] { layout.Path, layout.Id })
+            {
+                if (string.IsNullOrEmpty(probe)) continue;
+                foreach (var kv in choices)
+                {
+                    if (string.Equals(kv.Key, probe, StringComparison.OrdinalIgnoreCase)) return kv.Key;
+                    if (string.Equals(kv.Value, probe, StringComparison.OrdinalIgnoreCase)) return kv.Key;
+                }
+            }
+
+            // Id can appear embedded in a longer path-style key, e.g. "Layout[<guid>]".
+            foreach (var probe in new[] { layout.Id, layout.Path })
+            {
+                if (string.IsNullOrEmpty(probe)) continue;
+                foreach (var kv in choices)
+                {
+                    if (kv.Key != null && kv.Key.IndexOf(probe, StringComparison.OrdinalIgnoreCase) >= 0) return kv.Key;
+                    if (kv.Value != null && kv.Value.IndexOf(probe, StringComparison.OrdinalIgnoreCase) >= 0) return kv.Key;
+                }
+            }
+
+            // Name last: it is the weakest match, so it is only accepted when it is unambiguous.
+            if (!string.IsNullOrEmpty(layout.Name))
+            {
+                var byName = choices
+                    .Where(kv => string.Equals(kv.Value, layout.Name, StringComparison.OrdinalIgnoreCase)
+                              || string.Equals(kv.Key, layout.Name, StringComparison.OrdinalIgnoreCase))
+                    .Select(kv => kv.Key)
+                    .ToList();
+
+                if (byName.Count == 1) return byName[0];
+                if (byName.Count > 1)
+                    Log.Info($"{P} RemoveLayout: name '{layout.Name}' matched {byName.Count} candidates, refusing to guess.");
+            }
+
+            return null;
+        }
+
+        // AddLayout / RemoveLayout run server-side and can still be in flight when the call returns.
+        // Without polling, a server-side rejection (duplicate name, missing rights) would be reported
+        // to the user as a success. FlexViewViewItemWpfUserControl has its own copy of this for the
+        // federated AddView path; this one is kept separate because it logs each state transition,
+        // which is what makes a customer-side failure diagnosable.
+        private static void WaitForTask(ConfigItems.ServerTask task, string what)
+        {
+            if (task == null)
+                throw new InvalidOperationException($"{what}: the server returned no task.");
+
+            var deadline = DateTime.UtcNow + TaskTimeout;
+            var polls = 0;
+            var lastState = task.State;
+            Log.Info($"{P} {what}: task state={task.State} progress={task.Progress} path={task.Path}");
+
+            while (task.Progress < 100 && task.State != ConfigItems.StateEnum.Error && DateTime.UtcNow < deadline)
+            {
+                System.Threading.Thread.Sleep(200);
+                polls++;
+                try
+                {
+                    task.UpdateState();
+                }
+                catch (Exception ex)
+                {
+                    Log.Error($"{P} {what}: UpdateState threw after {polls} poll(s) - {ex.GetType().Name}: {ex.Message}", ex);
+                    throw;
+                }
+
+                if (task.State != lastState)
+                {
+                    Log.Info($"{P} {what}: state {lastState} -> {task.State} (progress {task.Progress})");
+                    lastState = task.State;
+                }
+            }
+
+            if (task.State == ConfigItems.StateEnum.Error)
+            {
+                var detail = task.ErrorText ?? task.ErrorCode ?? "no error text supplied by the server";
+                Log.Error($"{P} {what}: FAILED - state=Error code='{task.ErrorCode}' text='{task.ErrorText}'");
+                throw new InvalidOperationException($"{what} failed: {detail}");
+            }
+
+            if (task.Progress < 100)
+            {
+                Log.Error($"{P} {what}: TIMED OUT after {TaskTimeout.TotalSeconds:F0}s at progress {task.Progress}, state {task.State}.");
+                throw new TimeoutException(
+                    $"{what} did not finish within {TaskTimeout.TotalSeconds:F0} seconds. The server may still be working - reopen Manage Layouts to check.");
+            }
+
+            Log.Info($"{P} {what}: completed - state={task.State} progress={task.Progress} after {polls} poll(s).");
+        }
+
+        private static void TryClearCache(ConfigItems.LayoutFolder folder, string what)
+        {
+            try
+            {
+                folder.ClearChildrenCache();
+            }
+            catch (Exception ex)
+            {
+                // Non-fatal: the write already succeeded, this only affects what the next read sees.
+                Log.Info($"{P} {what}: ClearChildrenCache threw ({ex.GetType().Name}: {ex.Message}); list may be stale until reconnect.");
+            }
+        }
+
+        #endregion
+
+        #region Definition XML
+
+        // Builds the layout definition document. Shape and coordinate space are taken from the MIP SDK
+        // AddLayout sample: a flat list of ViewItem rectangles in a 1000x1000 space, with the picker
+        // thumbnail carried as a base64 PNG in ViewLayoutIcon.
+        //
+        //   <ViewLayout>
+        //     <ViewItems>
+        //       <ViewItem><Position><X>0</X><Y>0</Y></Position><Size><Width>1000</Width><Height>200</Height></Size></ViewItem>
+        //     </ViewItems>
+        //     <ViewLayoutIcon>iVBORw0…</ViewLayoutIcon>
+        //   </ViewLayout>
+        //
+        // Rectangles arrive straight from ConvertPanesToSdkLayout, already in that space, so nothing
+        // is scaled or rounded here - the arrangement the operator drew is what gets stored.
+        public static string BuildDefinitionXml(SdkRectangle[] rects, string iconBase64)
+        {
+            if (rects == null || rects.Length == 0)
+                throw new ArgumentException("A layout needs at least one pane.", nameof(rects));
+
+            var settings = new XmlWriterSettings
+            {
+                Indent = true,
+                IndentChars = "  ",
+                OmitXmlDeclaration = true,
+                Encoding = new UTF8Encoding(false)
+            };
+
+            var sb = new StringBuilder();
+            using (var writer = XmlWriter.Create(sb, settings))
+            {
+                writer.WriteStartElement("ViewLayout");
+                writer.WriteStartElement("ViewItems");
+
+                foreach (var r in rects)
+                {
+                    writer.WriteStartElement("ViewItem");
+
+                    writer.WriteStartElement("Position");
+                    WriteInt(writer, "X", r.X);
+                    WriteInt(writer, "Y", r.Y);
+                    writer.WriteEndElement();
+
+                    writer.WriteStartElement("Size");
+                    WriteInt(writer, "Width", r.Width);
+                    WriteInt(writer, "Height", r.Height);
+                    writer.WriteEndElement();
+
+                    writer.WriteEndElement();
+                }
+
+                writer.WriteEndElement();
+
+                if (!string.IsNullOrEmpty(iconBase64))
+                    writer.WriteElementString("ViewLayoutIcon", iconBase64);
+
+                writer.WriteEndElement();
+                writer.Flush();
+            }
+
+            return sb.ToString();
+        }
+
+        private static void WriteInt(XmlWriter writer, string name, int value)
+        {
+            writer.WriteElementString(name, value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        // Pane count for the Manage Layouts list. Best-effort: a layout authored by another
+        // integration may not parse, and an unreadable count must not hide the row.
+        private static int CountPanes(string definitionXml)
+        {
+            if (string.IsNullOrWhiteSpace(definitionXml)) return 0;
+            try
+            {
+                var doc = new XmlDocument { XmlResolver = null };
+                using (var sr = new StringReader(definitionXml))
+                using (var xr = XmlReader.Create(sr, new XmlReaderSettings { XmlResolver = null, DtdProcessing = DtdProcessing.Prohibit }))
+                {
+                    doc.Load(xr);
+                }
+                return doc.SelectNodes("/ViewLayout/ViewItems/ViewItem")?.Count ?? 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Info($"{P} CountPanes: could not parse definition xml ({ex.GetType().Name}: {ex.Message}).");
+                return 0;
+            }
+        }
+
+        #endregion
+
+        #region Helpers
+
+        private static T SafeGet<T>(Func<T> get) where T : class
+        {
+            try { return get(); } catch { return null; }
+        }
+
+        private static DateTime SafeGetDate(Func<DateTime> get)
+        {
+            try { return get(); } catch { return DateTime.MinValue; }
+        }
+
+        private static string Truncate(string s, int max)
+        {
+            if (string.IsNullOrEmpty(s) || s.Length <= max) return s;
+            return s.Substring(0, max) + $" ...[truncated, {s.Length} chars total]";
+        }
+
+        #endregion
+    }
+}

--- a/Smart Client Plugins/FlexView/Client/ManageLayoutsWindow.xaml
+++ b/Smart Client Plugins/FlexView/Client/ManageLayoutsWindow.xaml
@@ -1,0 +1,190 @@
+<Window x:Class="FlexView.Client.ManageLayoutsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Manage Layouts" Width="820" Height="520"
+        WindowStartupLocation="CenterOwner"
+        Background="#FF0D1117" ResizeMode="CanResize" MinWidth="640" MinHeight="380">
+    <Window.Resources>
+        <ControlTemplate x:Key="FlatButtonTemplate" TargetType="Button">
+            <Border x:Name="border" Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                    Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  RecognizesAccessKey="True"/>
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FF4A4F54"/>
+                    <Setter TargetName="border" Property="BorderBrush" Value="#FF666666"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FF555A5F"/>
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="border" Property="Background" Value="#FF26292D"/>
+                    <Setter TargetName="border" Property="BorderBrush" Value="#FF3A3F44"/>
+                    <Setter Property="Foreground" Value="#FF6E7681"/>
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+        <ControlTemplate x:Key="DangerButtonTemplate" TargetType="Button">
+            <Border x:Name="border" Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                    Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  RecognizesAccessKey="True"/>
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FFE5534C"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FFF06A64"/>
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="border" Property="Background" Value="#FF26292D"/>
+                    <Setter TargetName="border" Property="BorderBrush" Value="#FF3A3F44"/>
+                    <Setter Property="Foreground" Value="#FF6E7681"/>
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+        <Style x:Key="FlatButton" TargetType="Button">
+            <Setter Property="Background" Value="#FF3A3F44"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#FF555555"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="MinHeight" Value="28"/>
+            <Setter Property="Padding" Value="16,6"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template" Value="{StaticResource FlatButtonTemplate}"/>
+        </Style>
+
+        <Style x:Key="DangerButton" TargetType="Button">
+            <Setter Property="Background" Value="#FFC93C37"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#FFE5534C"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="MinHeight" Value="28"/>
+            <Setter Property="Padding" Value="16,6"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template" Value="{StaticResource DangerButtonTemplate}"/>
+        </Style>
+
+        <!-- Dark list. The stock GridView header and selection colors are system-light, so both
+             are retemplated to match the rest of the plugin. -->
+        <Style x:Key="DarkHeader" TargetType="GridViewColumnHeader">
+            <Setter Property="Foreground" Value="#FF8B949E"/>
+            <Setter Property="FontSize" Value="11.5"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="HorizontalContentAlignment" Value="Left"/>
+            <Setter Property="Padding" Value="8,6"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="GridViewColumnHeader">
+                        <Border Background="#FF161B22" BorderBrush="#FF30363D" BorderThickness="0,0,1,1"
+                                Padding="{TemplateBinding Padding}">
+                            <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                              VerticalAlignment="Center"/>
+                        </Border>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="DarkRow" TargetType="ListViewItem">
+            <Setter Property="Foreground" Value="#FFE6EDF3"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="Padding" Value="0"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListViewItem">
+                        <Border x:Name="bd" Background="Transparent" BorderBrush="#FF21262D"
+                                BorderThickness="0,0,0,1" Padding="0,5">
+                            <GridViewRowPresenter VerticalAlignment="Center"/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="bd" Property="Background" Value="#FF161B22"/>
+                            </Trigger>
+                            <Trigger Property="IsSelected" Value="True">
+                                <Setter TargetName="bd" Property="Background" Value="#FF1F3A5F"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Manage Layouts" Foreground="White" FontSize="14"
+                   FontWeight="SemiBold" Margin="0,0,0,10"/>
+
+        <Border Grid.Row="1" Background="#FF1C1A08" BorderBrush="#FF9E6A03" BorderThickness="1"
+                Padding="10,8" Margin="0,0,0,12">
+            <TextBlock Foreground="#FFD29922" FontSize="11.5" TextWrapping="Wrap"
+                       Text="Layouts are shared server configuration. Deleting one removes it for every operator on this site, and cannot be undone. Views already built from a layout keep working - they hold their own copy of the arrangement."/>
+        </Border>
+
+        <Border Grid.Row="2" BorderBrush="#FF30363D" BorderThickness="1" Background="#FF050811">
+            <Grid>
+                <ListView x:Name="layoutList" Background="Transparent" BorderThickness="0"
+                          Foreground="#FFE6EDF3"
+                          ItemContainerStyle="{StaticResource DarkRow}"
+                          SelectionMode="Single"
+                          SelectionChanged="OnSelectionChanged"
+                          ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                    <ListView.View>
+                        <GridView ColumnHeaderContainerStyle="{StaticResource DarkHeader}">
+                            <GridViewColumn Header="Layout" Width="240"
+                                            DisplayMemberBinding="{Binding Name}"/>
+                            <GridViewColumn Header="Group" Width="160"
+                                            DisplayMemberBinding="{Binding GroupName}"/>
+                            <GridViewColumn Header="Panes" Width="60"
+                                            DisplayMemberBinding="{Binding PaneText}"/>
+                            <GridViewColumn Header="Modified" Width="130"
+                                            DisplayMemberBinding="{Binding ModifiedText}"/>
+                            <GridViewColumn Header="Description" Width="180"
+                                            DisplayMemberBinding="{Binding Description}"/>
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+
+                <!-- Shown instead of the list while loading, and when the list has nothing in it. -->
+                <TextBlock x:Name="listPlaceholder" Foreground="#FF8B949E" FontSize="12.5"
+                           HorizontalAlignment="Center" VerticalAlignment="Center"
+                           TextWrapping="Wrap" TextAlignment="Center" MaxWidth="420"
+                           Visibility="Collapsed"/>
+            </Grid>
+        </Border>
+
+        <TextBlock x:Name="statusText" Grid.Row="3" Foreground="#FF8B949E" FontSize="11.5"
+                   Margin="0,10,0,0" TextWrapping="Wrap"/>
+
+        <StackPanel Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0">
+            <Button x:Name="refreshButton" Content="Refresh" Click="OnRefreshClick"
+                    Style="{StaticResource FlatButton}" Margin="0,0,8,0"/>
+            <Button x:Name="deleteButton" Content="Delete Layout" Click="OnDeleteClick"
+                    Style="{StaticResource DangerButton}" Margin="0,0,8,0" IsEnabled="False"/>
+            <Button Content="Close" Click="OnCloseClick" Style="{StaticResource FlatButton}"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Smart Client Plugins/FlexView/Client/ManageLayoutsWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ManageLayoutsWindow.xaml.cs
@@ -18,10 +18,26 @@ namespace FlexView.Client
         private List<LayoutRepository.LayoutGroupInfo> _groups = new List<LayoutRepository.LayoutGroupInfo>();
         private bool _busy;
 
+        // Set by any successful delete. The client-wide configuration reload that makes Add View
+        // notice the change is deliberately deferred to close: it is the only mechanism available
+        // (see LayoutRepository.RequestClientConfigurationReload) and it is expensive, so deleting
+        // five layouts should cost one reload rather than five. The list in this window does not
+        // depend on it - each refresh re-reads the server directly.
+        private bool _configChanged;
+
         public ManageLayoutsWindow()
         {
             InitializeComponent();
             Loaded += async (s, e) => await LoadAsync();
+
+            // Hooked on Closed rather than the Close button so the reload still happens when the
+            // window is dismissed with the title bar X or Alt+F4.
+            Closed += (s, e) =>
+            {
+                if (!_configChanged) return;
+                FlexViewDefinition.Log.Info("[FlexViewLayout] Manage Layouts closed after changes - reloading client configuration once.");
+                LayoutRepository.RequestClientConfigurationReload();
+            };
         }
 
         private async Task LoadAsync()
@@ -118,6 +134,10 @@ namespace FlexView.Client
             {
                 await Task.Run(() => LayoutRepository.RemoveLayout(layout));
                 FlexViewDefinition.Log.Info($"[FlexViewLayout] Delete of '{layout.Name}' succeeded.");
+
+                // The client keeps offering a deleted layout in Add View until it re-reads its
+                // configuration. Batched to window close rather than done here - see _configChanged.
+                _configChanged = true;
 
                 // Reload rather than removing the row locally, so the list reflects what the server
                 // actually holds - a partially applied delete would otherwise stay invisible.

--- a/Smart Client Plugins/FlexView/Client/ManageLayoutsWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/ManageLayoutsWindow.xaml.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace FlexView.Client
+{
+    // Lists every layout on the site and deletes the selected one.
+    //
+    // Both the load and the delete are management-server round trips, so both run on a background
+    // thread with the buttons disabled while in flight - the config API objects used here are the
+    // raw ConfigurationItems types, which FederationWalker already established are safe off the UI
+    // thread (unlike client-session objects such as ViewAndLayoutItem).
+    public partial class ManageLayoutsWindow : Window
+    {
+        private List<LayoutRepository.LayoutGroupInfo> _groups = new List<LayoutRepository.LayoutGroupInfo>();
+        private bool _busy;
+
+        public ManageLayoutsWindow()
+        {
+            InitializeComponent();
+            Loaded += async (s, e) => await LoadAsync();
+        }
+
+        private async Task LoadAsync()
+        {
+            SetBusy(true, "Loading layouts...");
+            ShowPlaceholder("Loading layouts from the management server...");
+            layoutList.ItemsSource = null;
+
+            try
+            {
+                var groups = await Task.Run(() => LayoutRepository.LoadGroups());
+                _groups = groups ?? new List<LayoutRepository.LayoutGroupInfo>();
+
+                var layouts = _groups.SelectMany(g => g.Layouts)
+                                     .OrderBy(l => l.GroupName, StringComparer.CurrentCultureIgnoreCase)
+                                     .ThenBy(l => l.Name, StringComparer.CurrentCultureIgnoreCase)
+                                     .ToList();
+
+                layoutList.ItemsSource = layouts;
+
+                if (layouts.Count == 0)
+                {
+                    ShowPlaceholder(_groups.Count == 0
+                        ? "This server exposes no layout groups."
+                        : "No layouts defined yet. Build an arrangement in FlexView and use Save as Layout.");
+                }
+                else
+                {
+                    HidePlaceholder();
+                }
+
+                // A group that failed to enumerate is reported rather than silently dropped: the
+                // list would otherwise look complete while missing entries.
+                var failed = _groups.Where(g => g.LoadError != null).ToList();
+                var summary = $"{layouts.Count} layout{(layouts.Count == 1 ? "" : "s")} in {_groups.Count} group{(_groups.Count == 1 ? "" : "s")}.";
+                if (failed.Count > 0)
+                {
+                    summary += $" {failed.Count} group(s) could not be read: "
+                             + string.Join("; ", failed.Select(g => $"{g.Name} ({g.LoadError})"))
+                             + " See MIPLog for details.";
+                    statusText.Foreground = System.Windows.Media.Brushes.Orange;
+                }
+                else
+                {
+                    statusText.ClearValue(ForegroundProperty);
+                    statusText.Foreground = new System.Windows.Media.SolidColorBrush(
+                        System.Windows.Media.Color.FromRgb(0x8B, 0x94, 0x9E));
+                }
+
+                SetBusy(false, summary);
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] ManageLayouts load failed - {ex.GetType().Name}: {ex.Message}", ex);
+                ShowPlaceholder("Layouts could not be loaded.");
+                SetBusy(false, $"Load failed: {ex.Message} See MIPLog for details.");
+                statusText.Foreground = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0xF8, 0x51, 0x49));
+            }
+
+            UpdateDeleteEnabled();
+        }
+
+        private async void OnRefreshClick(object sender, RoutedEventArgs e)
+        {
+            if (_busy) return;
+            await LoadAsync();
+        }
+
+        private async void OnDeleteClick(object sender, RoutedEventArgs e)
+        {
+            if (_busy) return;
+
+            var layout = layoutList.SelectedItem as LayoutRepository.LayoutInfo;
+            if (layout == null) return;
+
+            var confirmed = MessageDialog.Confirm(
+                "Delete Layout",
+                $"Delete the layout \"{layout.Name}\" from group \"{layout.GroupName}\"?\n\n"
+                + "It disappears from Add View for every operator on this site. This cannot be undone.",
+                okText: "Delete",
+                cancelText: "Cancel",
+                owner: this);
+
+            if (!confirmed)
+            {
+                FlexViewDefinition.Log.Info($"[FlexViewLayout] Delete of '{layout.Name}' cancelled by the operator.");
+                return;
+            }
+
+            SetBusy(true, $"Deleting \"{layout.Name}\"...");
+
+            try
+            {
+                await Task.Run(() => LayoutRepository.RemoveLayout(layout));
+                FlexViewDefinition.Log.Info($"[FlexViewLayout] Delete of '{layout.Name}' succeeded.");
+
+                // Reload rather than removing the row locally, so the list reflects what the server
+                // actually holds - a partially applied delete would otherwise stay invisible.
+                await LoadAsync();
+                statusText.Text = $"Deleted \"{layout.Name}\". " + statusText.Text;
+            }
+            catch (Exception ex)
+            {
+                FlexViewDefinition.Log.Error($"[FlexViewLayout] Delete of '{layout.Name}' failed - {ex.GetType().Name}: {ex.Message}", ex);
+                SetBusy(false, null);
+                MessageDialog.ShowError("Delete Failed",
+                    $"Could not delete \"{layout.Name}\":\n\n{ex.Message}\n\nSee MIPLog for the full detail.", this);
+                statusText.Text = $"Delete failed: {ex.Message}";
+                statusText.Foreground = new System.Windows.Media.SolidColorBrush(
+                    System.Windows.Media.Color.FromRgb(0xF8, 0x51, 0x49));
+            }
+        }
+
+        private void OnCloseClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+
+        private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            UpdateDeleteEnabled();
+        }
+
+        private void UpdateDeleteEnabled()
+        {
+            deleteButton.IsEnabled = !_busy && layoutList.SelectedItem is LayoutRepository.LayoutInfo;
+        }
+
+        private void SetBusy(bool busy, string status)
+        {
+            _busy = busy;
+            refreshButton.IsEnabled = !busy;
+            layoutList.IsEnabled = !busy;
+            if (status != null) statusText.Text = status;
+            UpdateDeleteEnabled();
+        }
+
+        private void ShowPlaceholder(string message)
+        {
+            listPlaceholder.Text = message;
+            listPlaceholder.Visibility = Visibility.Visible;
+        }
+
+        private void HidePlaceholder()
+        {
+            listPlaceholder.Visibility = Visibility.Collapsed;
+        }
+    }
+}

--- a/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml
+++ b/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml
@@ -1,0 +1,223 @@
+<Window x:Class="FlexView.Client.SaveLayoutWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Save as Layout" Width="560" SizeToContent="Height"
+        WindowStartupLocation="CenterOwner"
+        Background="#FF0D1117" ResizeMode="NoResize">
+    <Window.Resources>
+        <ControlTemplate x:Key="FlatButtonTemplate" TargetType="Button">
+            <Border x:Name="border" Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                    Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  RecognizesAccessKey="True"/>
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FF4A4F54"/>
+                    <Setter TargetName="border" Property="BorderBrush" Value="#FF666666"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FF555A5F"/>
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="border" Property="Background" Value="#FF26292D"/>
+                    <Setter Property="Foreground" Value="#FF6E7681"/>
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+        <ControlTemplate x:Key="AccentButtonTemplate" TargetType="Button">
+            <Border x:Name="border" Background="{TemplateBinding Background}"
+                    BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="1"
+                    Padding="{TemplateBinding Padding}" SnapsToDevicePixels="True">
+                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                  VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                  RecognizesAccessKey="True"/>
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FF2EA043"/>
+                </Trigger>
+                <Trigger Property="IsPressed" Value="True">
+                    <Setter TargetName="border" Property="Background" Value="#FF3AB550"/>
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="border" Property="Background" Value="#FF26292D"/>
+                    <Setter TargetName="border" Property="BorderBrush" Value="#FF3A3F44"/>
+                    <Setter Property="Foreground" Value="#FF6E7681"/>
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+        <Style x:Key="FlatButton" TargetType="Button">
+            <Setter Property="Background" Value="#FF3A3F44"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#FF555555"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template" Value="{StaticResource FlatButtonTemplate}"/>
+        </Style>
+        <Style x:Key="AccentButton" TargetType="Button">
+            <Setter Property="Background" Value="#FF238636"/>
+            <Setter Property="Foreground" Value="White"/>
+            <Setter Property="BorderBrush" Value="#FF2EA043"/>
+            <Setter Property="Cursor" Value="Hand"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template" Value="{StaticResource AccentButtonTemplate}"/>
+        </Style>
+
+        <!-- Dark ComboBox. The stock Aero2 template keeps a light toggle button and a white
+             popup regardless of Background, so the whole control is retemplated. -->
+        <ControlTemplate x:Key="ComboToggleTemplate" TargetType="ToggleButton">
+            <Border x:Name="border" Background="#FF050811" BorderBrush="#FF30363D" BorderThickness="1">
+                <Path x:Name="arrow" HorizontalAlignment="Right" VerticalAlignment="Center"
+                      Margin="0,0,8,0" Fill="#FF8B949E" Data="M 0 0 L 8 0 L 4 5 Z"/>
+            </Border>
+            <ControlTemplate.Triggers>
+                <Trigger Property="IsMouseOver" Value="True">
+                    <Setter TargetName="border" Property="BorderBrush" Value="#FF58A6FF"/>
+                </Trigger>
+                <Trigger Property="IsEnabled" Value="False">
+                    <Setter TargetName="border" Property="Background" Value="#FF1C2126"/>
+                    <Setter TargetName="arrow" Property="Fill" Value="#FF565C63"/>
+                </Trigger>
+            </ControlTemplate.Triggers>
+        </ControlTemplate>
+
+        <Style x:Key="DarkComboItem" TargetType="ComboBoxItem">
+            <Setter Property="Foreground" Value="#FFE6EDF3"/>
+            <Setter Property="Padding" Value="8,5"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBoxItem">
+                        <Border x:Name="bd" Background="Transparent" Padding="{TemplateBinding Padding}">
+                            <ContentPresenter/>
+                        </Border>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsHighlighted" Value="True">
+                                <Setter TargetName="bd" Property="Background" Value="#FF1F6FEB"/>
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="DarkCombo" TargetType="ComboBox">
+            <Setter Property="Foreground" Value="#FFE6EDF3"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="MinHeight" Value="26"/>
+            <Setter Property="ItemContainerStyle" Value="{StaticResource DarkComboItem}"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ComboBox">
+                        <Grid>
+                            <ToggleButton Template="{StaticResource ComboToggleTemplate}"
+                                          Focusable="False"
+                                          IsChecked="{Binding IsDropDownOpen, Mode=TwoWay, RelativeSource={RelativeSource TemplatedParent}}"
+                                          ClickMode="Press"/>
+                            <ContentPresenter Margin="8,0,24,0" VerticalAlignment="Center"
+                                              Content="{TemplateBinding SelectionBoxItem}"
+                                              ContentTemplate="{TemplateBinding SelectionBoxItemTemplate}"
+                                              IsHitTestVisible="False"/>
+                            <Popup IsOpen="{TemplateBinding IsDropDownOpen}" Placement="Bottom"
+                                   AllowsTransparency="True" Focusable="False" PopupAnimation="Slide">
+                                <Border Background="#FF0D1117" BorderBrush="#FF30363D" BorderThickness="1"
+                                        MinWidth="{TemplateBinding ActualWidth}" MaxHeight="240">
+                                    <ScrollViewer SnapsToDevicePixels="True">
+                                        <StackPanel IsItemsHost="True" KeyboardNavigation.DirectionalNavigation="Contained"/>
+                                    </ScrollViewer>
+                                </Border>
+                            </Popup>
+                        </Grid>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+    </Window.Resources>
+
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock Grid.Row="0" Text="Save Arrangement as Layout" Foreground="White" FontSize="14"
+                   FontWeight="SemiBold" Margin="0,0,0,12"/>
+
+        <!-- The single most important thing to say on this dialog: a layout is geometry, and any
+             view built from it starts empty. Saying it here is cheaper than a support ticket. -->
+        <Border Grid.Row="1" Background="#FF1C1A08" BorderBrush="#FF9E6A03" BorderThickness="1"
+                Padding="10,8" Margin="0,0,0,14">
+            <TextBlock Foreground="#FFD29922" FontSize="11.5" TextWrapping="Wrap"
+                       Text="A layout stores the pane arrangement only. Cameras and other view item content are not part of it, so a view created from this layout starts empty. Layouts are shared: everyone on this site sees it in Add View."/>
+        </Border>
+
+        <Grid Grid.Row="2">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
+            </Grid.RowDefinitions>
+
+            <DockPanel Grid.Row="0" Grid.Column="0" Margin="0,0,14,10">
+                <TextBlock Text="Name:" Foreground="#FFB0B0B0" VerticalAlignment="Center"
+                           Width="74" FontSize="12"/>
+                <TextBox x:Name="nameBox" Background="#FF050811" Foreground="White"
+                         CaretBrush="White" BorderBrush="#FF30363D" Padding="6,4" FontSize="12"
+                         VerticalContentAlignment="Center" TextChanged="OnNameChanged"/>
+            </DockPanel>
+
+            <DockPanel Grid.Row="1" Grid.Column="0" Margin="0,0,14,10">
+                <TextBlock Text="Description:" Foreground="#FFB0B0B0" VerticalAlignment="Center"
+                           Width="74" FontSize="12"/>
+                <TextBox x:Name="descriptionBox" Background="#FF050811" Foreground="White"
+                         CaretBrush="White" BorderBrush="#FF30363D" Padding="6,4" FontSize="12"
+                         VerticalContentAlignment="Center"/>
+            </DockPanel>
+
+            <DockPanel Grid.Row="2" Grid.Column="0" Margin="0,0,14,10">
+                <TextBlock Text="Group:" Foreground="#FFB0B0B0" VerticalAlignment="Center"
+                           Width="74" FontSize="12"/>
+                <ComboBox x:Name="groupCombo" Style="{StaticResource DarkCombo}"/>
+            </DockPanel>
+
+            <TextBlock x:Name="paneSummary" Grid.Row="3" Grid.Column="0" Margin="74,0,14,0"
+                       Foreground="#FF8B949E" FontSize="11.5" TextWrapping="Wrap"/>
+
+            <!-- Preview of exactly what will be stored, rendered from the same rectangles. -->
+            <Border Grid.Row="0" Grid.Column="1" Grid.RowSpan="4" Width="150" Height="120"
+                    Background="#FF050811" BorderBrush="#FF30363D" BorderThickness="1"
+                    VerticalAlignment="Top">
+                <Image x:Name="previewImage" Stretch="Uniform" Margin="4"
+                       RenderOptions.BitmapScalingMode="HighQuality"/>
+            </Border>
+        </Grid>
+
+        <StackPanel Grid.Row="3" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,18,0,0">
+            <TextBlock x:Name="errorText" Foreground="#FFF85149" FontSize="11.5"
+                       VerticalAlignment="Center" Margin="0,0,12,0" TextWrapping="Wrap"
+                       MaxWidth="300" Visibility="Collapsed"/>
+            <Button x:Name="saveButton" Content="Save Layout" Click="OnSaveClick"
+                    Style="{StaticResource AccentButton}"
+                    Padding="18,6" Margin="0,0,8,0" MinHeight="28"/>
+            <Button Content="Cancel" Click="OnCancelClick"
+                    Style="{StaticResource FlatButton}"
+                    Padding="18,6" MinHeight="28"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml
+++ b/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml
@@ -171,36 +171,27 @@
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
-                <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
 
             <DockPanel Grid.Row="0" Grid.Column="0" Margin="0,0,14,10">
                 <TextBlock Text="Name:" Foreground="#FFB0B0B0" VerticalAlignment="Center"
-                           Width="74" FontSize="12"/>
+                           Width="52" FontSize="12"/>
                 <TextBox x:Name="nameBox" Background="#FF050811" Foreground="White"
                          CaretBrush="White" BorderBrush="#FF30363D" Padding="6,4" FontSize="12"
                          VerticalContentAlignment="Center" TextChanged="OnNameChanged"/>
             </DockPanel>
 
             <DockPanel Grid.Row="1" Grid.Column="0" Margin="0,0,14,10">
-                <TextBlock Text="Description:" Foreground="#FFB0B0B0" VerticalAlignment="Center"
-                           Width="74" FontSize="12"/>
-                <TextBox x:Name="descriptionBox" Background="#FF050811" Foreground="White"
-                         CaretBrush="White" BorderBrush="#FF30363D" Padding="6,4" FontSize="12"
-                         VerticalContentAlignment="Center"/>
-            </DockPanel>
-
-            <DockPanel Grid.Row="2" Grid.Column="0" Margin="0,0,14,10">
                 <TextBlock Text="Group:" Foreground="#FFB0B0B0" VerticalAlignment="Center"
-                           Width="74" FontSize="12"/>
+                           Width="52" FontSize="12"/>
                 <ComboBox x:Name="groupCombo" Style="{StaticResource DarkCombo}"/>
             </DockPanel>
 
-            <TextBlock x:Name="paneSummary" Grid.Row="3" Grid.Column="0" Margin="74,0,14,0"
+            <TextBlock x:Name="paneSummary" Grid.Row="2" Grid.Column="0" Margin="52,0,14,0"
                        Foreground="#FF8B949E" FontSize="11.5" TextWrapping="Wrap"/>
 
             <!-- Preview of exactly what will be stored, rendered from the same rectangles. -->
-            <Border Grid.Row="0" Grid.Column="1" Grid.RowSpan="4" Width="150" Height="120"
+            <Border Grid.Row="0" Grid.Column="1" Grid.RowSpan="3" Width="150" Height="120"
                     Background="#FF050811" BorderBrush="#FF30363D" BorderThickness="1"
                     VerticalAlignment="Top">
                 <Image x:Name="previewImage" Stretch="Uniform" Margin="4"

--- a/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows;
+using System.Windows.Media;
+using SdkRectangle = System.Drawing.Rectangle;
+
+namespace FlexView.Client
+{
+    // Name / description / group picker for "Save as Layout", with a preview rendered from the very
+    // rectangles that will be written, so what the operator approves is what gets stored.
+    //
+    // The caller resolves the layout groups before opening this window: enumerating them is a
+    // management-server round trip, and doing it here would freeze the dialog as it appears.
+    public partial class SaveLayoutWindow : Window
+    {
+        private readonly List<LayoutRepository.LayoutGroupInfo> _groups;
+
+        // Internal, not public: these surface LayoutRepository's internal types, and the window
+        // class itself has to stay public for the XAML-generated partial to match.
+        internal string LayoutName => nameBox.Text?.Trim();
+        internal string LayoutDescription => descriptionBox.Text?.Trim() ?? "";
+        internal LayoutRepository.LayoutGroupInfo SelectedGroup =>
+            groupCombo.SelectedItem as LayoutRepository.LayoutGroupInfo;
+
+        public SaveLayoutWindow()
+        {
+            InitializeComponent();
+        }
+
+        internal SaveLayoutWindow(string defaultName,
+                                  List<LayoutRepository.LayoutGroupInfo> groups,
+                                  SdkRectangle[] rects) : this()
+        {
+            _groups = groups ?? new List<LayoutRepository.LayoutGroupInfo>();
+
+            if (!string.IsNullOrEmpty(defaultName))
+                nameBox.Text = defaultName;
+
+            groupCombo.ItemsSource = _groups;
+            groupCombo.DisplayMemberPath = nameof(LayoutRepository.LayoutGroupInfo.Name);
+            if (_groups.Count > 0) groupCombo.SelectedIndex = 0;
+
+            // No writable group means Save can never succeed. Say so on the dialog rather than
+            // letting the operator fill it in and fail on submit.
+            if (_groups.Count == 0)
+            {
+                ShowError("This server exposes no layout group to save into.");
+                saveButton.IsEnabled = false;
+                groupCombo.IsEnabled = false;
+            }
+
+            var count = rects?.Length ?? 0;
+            paneSummary.Text = count == 1
+                ? "1 pane will be stored."
+                : $"{count} panes will be stored.";
+
+            previewImage.Source = LayoutIconRenderer.RenderPreview(rects, 150, 120);
+
+            Loaded += (s, e) =>
+            {
+                nameBox.Focus();
+                nameBox.SelectAll();
+            };
+        }
+
+        private void OnNameChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+            // Clear a stale "name is required" as soon as the operator starts typing.
+            if (errorText.Visibility == Visibility.Visible && !string.IsNullOrWhiteSpace(nameBox.Text))
+                errorText.Visibility = Visibility.Collapsed;
+        }
+
+        private void OnSaveClick(object sender, RoutedEventArgs e)
+        {
+            if (string.IsNullOrWhiteSpace(LayoutName))
+            {
+                ShowError("Enter a name for the layout.");
+                nameBox.Focus();
+                return;
+            }
+
+            if (SelectedGroup == null)
+            {
+                ShowError("Select a layout group.");
+                return;
+            }
+
+            // Local duplicate check purely so the operator gets an instant answer instead of a
+            // round trip. The server remains the authority and its rejection is still surfaced.
+            var clash = SelectedGroup.Layouts
+                .FirstOrDefault(l => string.Equals(l.Name, LayoutName, StringComparison.OrdinalIgnoreCase));
+            if (clash != null)
+            {
+                ShowError($"'{clash.Name}' already exists in this group. Choose another name.");
+                nameBox.Focus();
+                nameBox.SelectAll();
+                return;
+            }
+
+            DialogResult = true;
+        }
+
+        private void OnCancelClick(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+
+        private void ShowError(string message)
+        {
+            errorText.Text = message;
+            errorText.Visibility = Visibility.Visible;
+        }
+    }
+}

--- a/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml.cs
+++ b/Smart Client Plugins/FlexView/Client/SaveLayoutWindow.xaml.cs
@@ -19,7 +19,6 @@ namespace FlexView.Client
         // Internal, not public: these surface LayoutRepository's internal types, and the window
         // class itself has to stay public for the XAML-generated partial to match.
         internal string LayoutName => nameBox.Text?.Trim();
-        internal string LayoutDescription => descriptionBox.Text?.Trim() ?? "";
         internal LayoutRepository.LayoutGroupInfo SelectedGroup =>
             groupCombo.SelectedItem as LayoutRepository.LayoutGroupInfo;
 

--- a/Smart Client Plugins/SCRemoteControl/SCRemoteControl.csproj
+++ b/Smart Client Plugins/SCRemoteControl/SCRemoteControl.csproj
@@ -42,4 +42,10 @@
     <EmbeddedResource Include="OpenApi\swagger-ui\swagger-ui.css" />
   </ItemGroup>
 
+  <Target Name="MergeSwashbuckle" AfterTargets="MergeCommunitySDK" BeforeTargets="MIPDeploy"
+          Condition="Exists('$(TargetDir)Swashbuckle.Core.dll')">
+    <Exec Command="&quot;$(PkgILRepack)\tools\ILRepack.exe&quot; /internalize /lib:&quot;$(TargetDir).&quot; /out:&quot;$(TargetPath)&quot; &quot;$(TargetPath)&quot; &quot;$(TargetDir)Swashbuckle.Core.dll&quot;" />
+    <Delete Files="$(TargetDir)Swashbuckle.Core.dll;$(TargetDir)Swashbuckle.Core.pdb" />
+  </Target>
+
 </Project>

--- a/docs/plugins/smart-client/flexview.md
+++ b/docs/plugins/smart-client/flexview.md
@@ -53,6 +53,26 @@ When a view is loaded, its existing camera and built-in view-item assignments (C
 
 The created view works like any standard XProtect view. Assign cameras to empty slots in the normal Smart Client view builder.
 
+## Saving an Arrangement as a Layout
+
+A **view** is a single saved screen with cameras in it. A **layout** is a reusable template - one of the shapes offered in Smart Client setup mode under **Add View**, next to the built-in 1x1 and 2x2 grids.
+
+Click **Save as Layout** to store the current arrangement as one of those templates.
+
+!!! warning "A layout stores the arrangement only"
+    Layouts carry geometry and nothing else. Cameras and other view item content are not part of a layout, so a view created from one starts empty. If you want to keep the cameras, save a view instead.
+
+The dialog asks for a name, an optional description, and which layout group to file it under, and previews exactly what will be stored. The panes are written at full precision - the arrangement you drew is the arrangement the template produces.
+
+## Managing Layouts
+
+Click **Manage Layouts** to list every layout defined on the site and delete the ones you no longer want. The list shows the owning group, pane count, last-modified date, and description.
+
+!!! danger "Deleting a layout affects everyone"
+    Layouts are shared server configuration, not personal settings. Deleting one removes it from **Add View** for every operator on the site, and it cannot be undone. Views already built from that layout keep working, because each view holds its own copy of the arrangement.
+
+Both buttons write to the management server and need configuration rights that a standard operator account usually does not have. If either fails, the message names the reason and the full detail is written to `MIPLog.txt` with the `[FlexViewLayout]` prefix.
+
 ## Controls
 
 | Action | How |
@@ -65,4 +85,6 @@ The created view works like any standard XProtect view. Assign cameras to empty 
 | **Open view** | Click **Open View**, confirm the recreate notice, pick a view (use the search field to filter) |
 | **Save** | Save the current view - recreates an existing view with cameras restored |
 | **Save As** | Duplicate an opened view to a new name/folder, carrying camera assignments |
+| **Save as Layout** | Store the arrangement as a reusable template in **Add View**. Panes only, no cameras |
+| **Manage Layouts** | List the site's layouts and delete them. Deletion is site-wide |
 </div>


### PR DESCRIPTION
Adds two toolbar buttons to Flex View, fixes a customer-reported crash in SC Remote Control, and cuts the 3.4.30 changelog.

## Flex View: Save as Layout / Manage Layouts

**Save as Layout** stores the current pane arrangement as a reusable template in Smart Client setup mode under **Add View**, next to the built-in 1x1 / 2x2 grids. **Manage Layouts** lists every layout on the site and deletes the selected one.

**A layout is geometry and nothing else.** The SDK's `Layout` type carries only `Id`, `Name`, `Description` and `DefinitionXml` — there is no camera collection and no way to attach one, so a view created from a saved layout starts empty. That is what a layout *is*, not a gap in the implementation, and it is stated on the save dialog, in the success message, in the tooltip and in the docs. A "Save as Layout" that silently dropped the cameras would read as a bug.

The arrangement itself survives exactly: `ConvertPanesToSdkLayout` already emits rectangles in the 0..1000 space the layout definition XML uses, so panes go in unscaled and unrounded.

Layouts are shared Management Server configuration rather than per-user state, which shapes the rest:

- Deleting is site-wide and irreversible; both the dialog and the confirmation say so. Views already built from a layout are unaffected — each holds its own copy of the arrangement.
- Both operations need configuration rights a normal operator usually lacks, so failures name that as the likely cause instead of surfacing a bare exception.
- Add and Remove are server-side tasks that can still be in flight when the call returns, so both are polled to completion. Without that, a rejected write reports as success.

Everything logs under `[FlexViewLayout]`, matching the existing `[FlexViewFed]` prefix.

### Three things found by testing against a live system

- **`ItemSelection` wants the item path, not the display name.** The server's `ItemSelectionValues` is `{display name -> path}`; submitting the key returned `ArgumentMIPException: itemSelection`. The resolver now submits whichever side of the pair *is* the identifier, so it survives a future orientation change, and logs which side it chose.
- **The client never saw the change.** `ClearChildrenCache` only clears our own `ManagementServer` instance. `Configuration.RefreshConfiguration(Kind.Layout)` is not an option either — Milestone Development have [confirmed](https://forum.milestonesys.com/t/12005/6) it is a no-op for built-in kinds, and it would flush the wrong cache anyway (the MIP item cache, not the one the picker reads). The client-wide reload is the only lever, so it is sent on save and batched to one reload on close in Manage Layouts.
- **The icon was 64x64.** The picker draws at native size, so it towered over the built-in 16x16 entries and stretched its row. Now 16x16, with each edge rounded independently so sub-pixel panes cannot silently vanish.

## Fix: SC Remote Control crash on customer machines

```
Method not found: 'Swashbuckle.Application.SwaggerEnabledConfiguration
Swashbuckle.Application.HttpConfigurationExtensions.EnableSwagger(...)'
```

Swashbuckle.Core pins `AssemblyVersion` at **1.0.0.0** in every package release, so 5.2, 5.5 and 5.6 all present the identical identity `Swashbuckle.Core, Version=1.0.0.0, PublicKeyToken=cd1bb07a5ac7c7bc`. MIP plugins share one AppDomain: whichever build loads that identity first wins, and the copy beside our plugin is ignored. A customer running another plugin with a different Swashbuckle got our 5.6-compiled call dispatched into someone else's build.

`MissingMethodException` rather than `FileNotFound`/`TypeLoad` is the tell — the assembly loaded fine and lacked the method.

Same mechanism, same remedy as the existing `MergeLiveCharts` target: ILRepack `/internalize`. Verified on the built output — 83 Swashbuckle types merged in, 0 still public, no external Swashbuckle reference remaining, and `Swashbuckle.Core.dll` no longer shipped.

Only Swashbuckle is merged. `Newtonsoft.Json` (13.0.0.0 for all 13.x) and `Newtonsoft.Json.Bson` (1.0.0.0) carry the same risk but must stay external — `System.Net.Http.Formatting` binds to them across the assembly boundary.

## Verification

- Full solution builds clean; docs build with `mkdocs --strict`.
- Save, picker appearance and delete exercised end to end against a live site (42 layouts across 4 groups).
- A WPF harness realizes both new windows off-screen and asserts every column and the group combo actually paint, with binding-error tracing on. It caught a real bug: the row models exposed public fields, and WPF binds only through the property system, so the Layout and Description columns rendered empty while the computed-property columns beside them worked. Both models are properties now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)