### PR TITLE
ColoredTimeline does not filter the chosen camera; fix marker sort crash

### DIFF
--- a/Admin Plugins/ColoredTimeline/Background/ColoredTimelineMarkerSource.cs
+++ b/Admin Plugins/ColoredTimeline/Background/ColoredTimelineMarkerSource.cs
@@ -124,8 +124,9 @@ namespace ColoredTimeline.Background
                 EventLine[] events;
                 try
                 {
-                    events = _alarmClient.GetEventLines(0, int.MaxValue, BuildFilter(interval))
-                             ?? Array.Empty<EventLine>();
+                    events = OnlyCamera(_alarmClient.GetEventLines(0, int.MaxValue, BuildFilter(interval)), CameraFqid.ObjectId)
+                    .OrderBy(e => e.Timestamp)
+                    .ToArray();
                 }
                 catch (OperationCanceledException) { return; }
                 catch (ObjectDisposedException) { return; }
@@ -150,10 +151,19 @@ namespace ColoredTimeline.Background
                 _log.Info($"Marker '{Title}' cam={CameraFqid.ObjectId} window=" +
                           $"{interval.StartTime.ToLocalTime():HH:mm:ss}..{interval.EndTime.ToLocalTime():HH:mm:ss} -> {events.Length} marker(s)");
 
+                // Smart Client's marker publish requires strictly increasing timestamps.
+                // At high event rates the Event Log has duplicate (second-precision)
+                // timestamps, which fail with "Argument not sorted" and drop the whole
+                // batch. Sort, then nudge any duplicate forward by one tick.
                 var areas = new List<TimelineDataArea>(events.Length);
+                DateTime lastTs = DateTime.MinValue;
                 foreach (var e in events)
                 {
-                    var area = new TimelineDataArea(new TimeInterval(e.Timestamp, e.Timestamp));
+                    var ts = e.Timestamp;
+                    if (ts <= lastTs) ts = lastTs.AddTicks(1);
+                    lastTs = ts;
+
+                    var area = new TimelineDataArea(new TimeInterval(ts, ts));
                     var info = new MarkerInfo
                     {
                         RuleName = RuleName,
@@ -195,6 +205,10 @@ namespace ColoredTimeline.Background
                 _log.Error($"Marker QueryAndPublish failed for '{Title}': {ex.Message}");
             }
         }
+
+        private static EventLine[] OnlyCamera(EventLine[] events, Guid cameraId) =>
+        (events ?? Array.Empty<EventLine>()).Where(e => e.CameraId == cameraId).ToArray();
+
 
         private void EnsureAlarmClient()
         {

--- a/Admin Plugins/ColoredTimeline/Background/ColoredTimelineSequenceSource.cs
+++ b/Admin Plugins/ColoredTimeline/Background/ColoredTimelineSequenceSource.cs
@@ -92,8 +92,8 @@ namespace ColoredTimeline.Background
                         ? Task.Run(() => _alarmClient.GetEventLines(0, int.MaxValue, stopFilter), _cts.Token)
                         : Task.FromResult(Array.Empty<EventLine>());
                     Task.WaitAll(new Task[] { startTask, stopTask }, _cts.Token);
-                    startEvents = startTask.Result;
-                    stopEvents = stopTask.Result;
+                    startEvents = OnlyCamera(startTask.Result, CameraFqid.ObjectId);
+                    stopEvents = OnlyCamera(stopTask.Result, CameraFqid.ObjectId);
                 }
                 catch (OperationCanceledException) { return; }
                 catch (ObjectDisposedException) { return; }
@@ -218,6 +218,15 @@ namespace ColoredTimeline.Background
             }
             return sequences;
         }
+
+
+        // On this server version GetEventLines does not honour the Target.CameraId filter
+        // condition - it returns events for every camera, not just this one (confirmed by
+        // comparing the returned row count against a direct Event Log DB query). Filter
+        // client-side so the result is correct regardless.
+        private static EventLine[] OnlyCamera(EventLine[] events, Guid cameraId) =>
+        (events ?? Array.Empty<EventLine>()).Where(e => e.CameraId == cameraId).ToArray();
+
 
         private void EnsureAlarmClient()
         {


### PR DESCRIPTION
GetEventLines does not honour the Target.CameraId filter condition and returns every camera's events, so a rule's timeline shows other cameras' events too. Added a client-side camera filter in both Background sources. Also the marker source now sorts by timestamp and nudges duplicate second-precision timestamps forward one tick, so high event rates no longer make the whole marker batch fail with an 'Argument not sorted' error.